### PR TITLE
Restore processing of type definitions in interfaces.

### DIFF
--- a/examples/deadcode/src/deadcode.txt
+++ b/examples/deadcode/src/deadcode.txt
@@ -1,18 +1,18 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ReasonComponent.cmt
-  addValueDeclaration component ReasonComponent.re:3:4 path:+ReasonComponent
+  addValueDeclaration +component ReasonComponent.re:3:4 path:+ReasonComponent
   addTypeDeclaration name ReasonComponent.re:7:2 path:+ReasonComponent.person
   addTypeDeclaration surname ReasonComponent.re:8:2 path:+ReasonComponent.person
   addTypeDeclaration type_ ReasonComponent.re:9:2 path:+ReasonComponent.person
   addTypeDeclaration polymorphicPayload ReasonComponent.re:11:2 path:+ReasonComponent.person
-  addValueDeclaration onClick ReasonComponent.re:15:4 path:+ReasonComponent
-  addValueDeclaration make ReasonComponent.re:18:4 path:+ReasonComponent
-  addValueDeclaration minus ReasonComponent.re:43:4 path:+ReasonComponent
-  addValueDeclaration useTypeDefinedInAnotherModule ReasonComponent.re:46:4 path:+ReasonComponent
+  addValueDeclaration +onClick ReasonComponent.re:15:4 path:+ReasonComponent
+  addValueDeclaration +make ReasonComponent.re:18:4 path:+ReasonComponent
+  addValueDeclaration +minus ReasonComponent.re:43:4 path:+ReasonComponent
+  addValueDeclaration +useTypeDefinedInAnotherModule ReasonComponent.re:46:4 path:+ReasonComponent
   addTypeDeclaration A ReasonComponent.re:50:4 path:+ReasonComponent.t
   addTypeDeclaration B ReasonComponent.re:51:4 path:+ReasonComponent.t
   addTypeDeclaration C ReasonComponent.re:52:4 path:+ReasonComponent.t
-  addValueDeclaration tToString ReasonComponent.re:55:4 path:+ReasonComponent
-  addValueDeclaration useRecordsCoord ReasonComponent.re:63:4 path:+ReasonComponent
+  addValueDeclaration +tToString ReasonComponent.re:55:4 path:+ReasonComponent
+  addValueDeclaration +useRecordsCoord ReasonComponent.re:63:4 path:+ReasonComponent
   addValueReference ReasonComponent.re:3:4 --> ReasonReact.rei:153:0
   addTypeDeclaration +name ReasonComponent.re:7:2 path:+ReasonComponent.+person
   addTypeDeclaration +surname ReasonComponent.re:8:2 path:+ReasonComponent.+person
@@ -50,35 +50,35 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/FirstClassModulesInterface.cmti
   addTypeDeclaration x FirstClassModulesInterface.rei:3:2 path:FirstClassModulesInterface.record
   addTypeDeclaration y FirstClassModulesInterface.rei:4:2 path:FirstClassModulesInterface.record
-  addValueDeclaration r FirstClassModulesInterface.rei:7:0 path:FirstClassModulesInterface
+  addValueDeclaration +r FirstClassModulesInterface.rei:7:0 path:FirstClassModulesInterface
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Types.cmt
-  addValueDeclaration someIntList Types.re:5:4 path:+Types
-  addValueDeclaration map Types.re:8:4 path:+Types
+  addValueDeclaration +someIntList Types.re:5:4 path:+Types
+  addValueDeclaration +map Types.re:8:4 path:+Types
   addTypeDeclaration A Types.re:12:4 path:+Types.typeWithVars
   addTypeDeclaration B Types.re:13:4 path:+Types.typeWithVars
-  addValueDeclaration swap Types.re:28:8 path:+Types
+  addValueDeclaration +swap Types.re:28:8 path:+Types
   addTypeDeclaration self Types.re:35:22 path:+Types.selfRecursive
   addTypeDeclaration b Types.re:38:27 path:+Types.mutuallyRecursiveA
   addTypeDeclaration a Types.re:39:26 path:+Types.mutuallyRecursiveB
-  addValueDeclaration selfRecursiveConverter Types.re:46:4 path:+Types
-  addValueDeclaration mutuallyRecursiveConverter Types.re:53:4 path:+Types
-  addValueDeclaration testFunctionOnOptionsAsArgument Types.re:56:4 path:+Types
+  addValueDeclaration +selfRecursiveConverter Types.re:46:4 path:+Types
+  addValueDeclaration +mutuallyRecursiveConverter Types.re:53:4 path:+Types
+  addValueDeclaration +testFunctionOnOptionsAsArgument Types.re:56:4 path:+Types
   addTypeDeclaration A Types.re:60:4 path:+Types.opaqueVariant
   addTypeDeclaration B Types.re:61:4 path:+Types.opaqueVariant
-  addValueDeclaration stringT Types.re:64:4 path:+Types
-  addValueDeclaration jsStringT Types.re:67:4 path:+Types
-  addValueDeclaration jsString2T Types.re:70:4 path:+Types
-  addValueDeclaration jsonStringify Types.re:82:4 path:+Types
+  addValueDeclaration +stringT Types.re:64:4 path:+Types
+  addValueDeclaration +jsStringT Types.re:67:4 path:+Types
+  addValueDeclaration +jsString2T Types.re:70:4 path:+Types
+  addValueDeclaration +jsonStringify Types.re:82:4 path:+Types
   addTypeDeclaration i Types.re:91:2 path:+Types.record
   addTypeDeclaration s Types.re:92:2 path:+Types.record
-  addValueDeclaration testConvertNull Types.re:96:4 path:+Types
-  addValueDeclaration testMarshalFields Types.re:118:4 path:+Types
-  addValueDeclaration setMatch Types.re:134:4 path:+Types
+  addValueDeclaration +testConvertNull Types.re:96:4 path:+Types
+  addValueDeclaration +testMarshalFields Types.re:118:4 path:+Types
+  addValueDeclaration +setMatch Types.re:134:4 path:+Types
   addTypeDeclaration id Types.re:139:19 path:+Types.someRecord
-  addValueDeclaration testInstantiateTypeParameter Types.re:144:4 path:+Types
-  addValueDeclaration currentTime Types.re:154:4 path:+Types
-  addValueDeclaration i64Const Types.re:163:4 path:+Types
-  addValueDeclaration optFunction Types.re:166:4 path:+Types
+  addValueDeclaration +testInstantiateTypeParameter Types.re:144:4 path:+Types
+  addValueDeclaration +currentTime Types.re:154:4 path:+Types
+  addValueDeclaration +i64Const Types.re:163:4 path:+Types
+  addValueDeclaration +optFunction Types.re:166:4 path:+Types
   addTypeDeclaration +A Types.re:12:4 path:+Types.+typeWithVars
   addTypeDeclaration +B Types.re:13:4 path:+Types.+typeWithVars
   addValueReference Types.re:28:8 --> Types.re:28:16
@@ -109,8 +109,8 @@
   addValueReference Types.re:144:4 --> Types.re:144:36
   addValueDeclaration +x Types.re:173:6 path:+Types.ObjectId
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ErrorHandler.cmt
-  addValueDeclaration notify ErrorHandler.re:7:6 path:+ErrorHandler.Make
-  addValueDeclaration x ErrorHandler.re:12:4 path:+ErrorHandler
+  addValueDeclaration +notify ErrorHandler.re:7:6 path:+ErrorHandler.Make
+  addValueDeclaration +x ErrorHandler.re:12:4 path:+ErrorHandler
   addValueReference ErrorHandler.re:7:6 --> ErrorHandler.re:7:15
   addValueReference ErrorHandler.re:7:6 --> ErrorHandler.re:3:2
   addValueReference ErrorHandler.rei:3:2 --> ErrorHandler.re:3:2
@@ -118,138 +118,138 @@
   addValueReference ErrorHandler.rei:5:32 --> ErrorHandler.re:7:6
   addValueReference ErrorHandler.rei:7:0 --> ErrorHandler.re:12:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImmutableArray.cmt
-  addValueDeclaration fromT ImmutableArray.re:5:2 path:+ImmutableArray.Array
-  addValueDeclaration fromTp ImmutableArray.re:6:2 path:+ImmutableArray.Array
-  addValueDeclaration fromTT ImmutableArray.re:7:2 path:+ImmutableArray.Array
-  addValueDeclaration toT ImmutableArray.re:8:2 path:+ImmutableArray.Array
-  addValueDeclaration toTp ImmutableArray.re:9:2 path:+ImmutableArray.Array
-  addValueDeclaration toT2 ImmutableArray.re:10:2 path:+ImmutableArray.Array
-  addValueDeclaration fromArray ImmutableArray.re:14:6 path:+ImmutableArray.Array
-  addValueDeclaration toArray ImmutableArray.re:16:6 path:+ImmutableArray.Array
-  addValueDeclaration length ImmutableArray.re:20:6 path:+ImmutableArray.Array
-  addValueDeclaration size ImmutableArray.re:22:6 path:+ImmutableArray.Array
-  addValueDeclaration get ImmutableArray.re:24:6 path:+ImmutableArray.Array
-  addValueDeclaration getExn ImmutableArray.re:26:6 path:+ImmutableArray.Array
-  addValueDeclaration getUnsafe ImmutableArray.re:28:6 path:+ImmutableArray.Array
-  addValueDeclaration getUndefined ImmutableArray.re:30:6 path:+ImmutableArray.Array
-  addValueDeclaration shuffle ImmutableArray.re:32:6 path:+ImmutableArray.Array
-  addValueDeclaration reverse ImmutableArray.re:34:6 path:+ImmutableArray.Array
-  addValueDeclaration makeUninitialized ImmutableArray.re:36:6 path:+ImmutableArray.Array
-  addValueDeclaration makeUninitializedUnsafe ImmutableArray.re:38:6 path:+ImmutableArray.Array
-  addValueDeclaration make ImmutableArray.re:40:6 path:+ImmutableArray.Array
-  addValueDeclaration range ImmutableArray.re:42:6 path:+ImmutableArray.Array
-  addValueDeclaration rangeBy ImmutableArray.re:44:6 path:+ImmutableArray.Array
-  addValueDeclaration makeByU ImmutableArray.re:46:6 path:+ImmutableArray.Array
-  addValueDeclaration makeBy ImmutableArray.re:47:6 path:+ImmutableArray.Array
-  addValueDeclaration makeByAndShuffleU ImmutableArray.re:49:6 path:+ImmutableArray.Array
-  addValueDeclaration makeByAndShuffle ImmutableArray.re:50:6 path:+ImmutableArray.Array
-  addValueDeclaration zip ImmutableArray.re:52:6 path:+ImmutableArray.Array
-  addValueDeclaration zipByU ImmutableArray.re:54:6 path:+ImmutableArray.Array
-  addValueDeclaration zipBy ImmutableArray.re:55:6 path:+ImmutableArray.Array
-  addValueDeclaration unzip ImmutableArray.re:57:6 path:+ImmutableArray.Array
-  addValueDeclaration concat ImmutableArray.re:59:6 path:+ImmutableArray.Array
-  addValueDeclaration concatMany ImmutableArray.re:61:6 path:+ImmutableArray.Array
-  addValueDeclaration slice ImmutableArray.re:63:6 path:+ImmutableArray.Array
-  addValueDeclaration sliceToEnd ImmutableArray.re:66:6 path:+ImmutableArray.Array
-  addValueDeclaration copy ImmutableArray.re:68:6 path:+ImmutableArray.Array
-  addValueDeclaration forEachU ImmutableArray.re:70:6 path:+ImmutableArray.Array
-  addValueDeclaration forEach ImmutableArray.re:71:6 path:+ImmutableArray.Array
-  addValueDeclaration mapU ImmutableArray.re:73:6 path:+ImmutableArray.Array
-  addValueDeclaration map ImmutableArray.re:74:6 path:+ImmutableArray.Array
-  addValueDeclaration keepWithIndexU ImmutableArray.re:76:6 path:+ImmutableArray.Array
-  addValueDeclaration keepWithIndex ImmutableArray.re:77:6 path:+ImmutableArray.Array
-  addValueDeclaration keepMapU ImmutableArray.re:79:6 path:+ImmutableArray.Array
-  addValueDeclaration keepMap ImmutableArray.re:80:6 path:+ImmutableArray.Array
-  addValueDeclaration forEachWithIndexU ImmutableArray.re:82:6 path:+ImmutableArray.Array
-  addValueDeclaration forEachWithIndex ImmutableArray.re:83:6 path:+ImmutableArray.Array
-  addValueDeclaration mapWithIndexU ImmutableArray.re:85:6 path:+ImmutableArray.Array
-  addValueDeclaration mapWithIndex ImmutableArray.re:86:6 path:+ImmutableArray.Array
-  addValueDeclaration partitionU ImmutableArray.re:88:6 path:+ImmutableArray.Array
-  addValueDeclaration partition ImmutableArray.re:89:6 path:+ImmutableArray.Array
-  addValueDeclaration reduceU ImmutableArray.re:91:6 path:+ImmutableArray.Array
-  addValueDeclaration reduce ImmutableArray.re:92:6 path:+ImmutableArray.Array
-  addValueDeclaration reduceReverseU ImmutableArray.re:94:6 path:+ImmutableArray.Array
-  addValueDeclaration reduceReverse ImmutableArray.re:95:6 path:+ImmutableArray.Array
-  addValueDeclaration reduceReverse2U ImmutableArray.re:97:6 path:+ImmutableArray.Array
-  addValueDeclaration reduceReverse2 ImmutableArray.re:99:6 path:+ImmutableArray.Array
-  addValueDeclaration someU ImmutableArray.re:102:6 path:+ImmutableArray.Array
-  addValueDeclaration some ImmutableArray.re:103:6 path:+ImmutableArray.Array
-  addValueDeclaration everyU ImmutableArray.re:105:6 path:+ImmutableArray.Array
-  addValueDeclaration every ImmutableArray.re:106:6 path:+ImmutableArray.Array
-  addValueDeclaration every2U ImmutableArray.re:108:6 path:+ImmutableArray.Array
-  addValueDeclaration every2 ImmutableArray.re:109:6 path:+ImmutableArray.Array
-  addValueDeclaration some2U ImmutableArray.re:111:6 path:+ImmutableArray.Array
-  addValueDeclaration some2 ImmutableArray.re:112:6 path:+ImmutableArray.Array
-  addValueDeclaration cmpU ImmutableArray.re:114:6 path:+ImmutableArray.Array
-  addValueDeclaration cmp ImmutableArray.re:115:6 path:+ImmutableArray.Array
-  addValueDeclaration eqU ImmutableArray.re:117:6 path:+ImmutableArray.Array
-  addValueDeclaration eq ImmutableArray.re:118:6 path:+ImmutableArray.Array
-  addValueDeclaration fromT ImmutableArray.re:5:2 path:+ImmutableArray
-  addValueDeclaration fromTp ImmutableArray.re:6:2 path:+ImmutableArray
-  addValueDeclaration fromTT ImmutableArray.re:7:2 path:+ImmutableArray
-  addValueDeclaration toT ImmutableArray.re:8:2 path:+ImmutableArray
-  addValueDeclaration toTp ImmutableArray.re:9:2 path:+ImmutableArray
-  addValueDeclaration toT2 ImmutableArray.re:10:2 path:+ImmutableArray
-  addValueDeclaration fromArray ImmutableArray.re:14:6 path:+ImmutableArray
-  addValueDeclaration toArray ImmutableArray.re:16:6 path:+ImmutableArray
-  addValueDeclaration length ImmutableArray.re:20:6 path:+ImmutableArray
-  addValueDeclaration size ImmutableArray.re:22:6 path:+ImmutableArray
-  addValueDeclaration get ImmutableArray.re:24:6 path:+ImmutableArray
-  addValueDeclaration getExn ImmutableArray.re:26:6 path:+ImmutableArray
-  addValueDeclaration getUnsafe ImmutableArray.re:28:6 path:+ImmutableArray
-  addValueDeclaration getUndefined ImmutableArray.re:30:6 path:+ImmutableArray
-  addValueDeclaration shuffle ImmutableArray.re:32:6 path:+ImmutableArray
-  addValueDeclaration reverse ImmutableArray.re:34:6 path:+ImmutableArray
-  addValueDeclaration makeUninitialized ImmutableArray.re:36:6 path:+ImmutableArray
-  addValueDeclaration makeUninitializedUnsafe ImmutableArray.re:38:6 path:+ImmutableArray
-  addValueDeclaration make ImmutableArray.re:40:6 path:+ImmutableArray
-  addValueDeclaration range ImmutableArray.re:42:6 path:+ImmutableArray
-  addValueDeclaration rangeBy ImmutableArray.re:44:6 path:+ImmutableArray
-  addValueDeclaration makeByU ImmutableArray.re:46:6 path:+ImmutableArray
-  addValueDeclaration makeBy ImmutableArray.re:47:6 path:+ImmutableArray
-  addValueDeclaration makeByAndShuffleU ImmutableArray.re:49:6 path:+ImmutableArray
-  addValueDeclaration makeByAndShuffle ImmutableArray.re:50:6 path:+ImmutableArray
-  addValueDeclaration zip ImmutableArray.re:52:6 path:+ImmutableArray
-  addValueDeclaration zipByU ImmutableArray.re:54:6 path:+ImmutableArray
-  addValueDeclaration zipBy ImmutableArray.re:55:6 path:+ImmutableArray
-  addValueDeclaration unzip ImmutableArray.re:57:6 path:+ImmutableArray
-  addValueDeclaration concat ImmutableArray.re:59:6 path:+ImmutableArray
-  addValueDeclaration concatMany ImmutableArray.re:61:6 path:+ImmutableArray
-  addValueDeclaration slice ImmutableArray.re:63:6 path:+ImmutableArray
-  addValueDeclaration sliceToEnd ImmutableArray.re:66:6 path:+ImmutableArray
-  addValueDeclaration copy ImmutableArray.re:68:6 path:+ImmutableArray
-  addValueDeclaration forEachU ImmutableArray.re:70:6 path:+ImmutableArray
-  addValueDeclaration forEach ImmutableArray.re:71:6 path:+ImmutableArray
-  addValueDeclaration mapU ImmutableArray.re:73:6 path:+ImmutableArray
-  addValueDeclaration map ImmutableArray.re:74:6 path:+ImmutableArray
-  addValueDeclaration keepWithIndexU ImmutableArray.re:76:6 path:+ImmutableArray
-  addValueDeclaration keepWithIndex ImmutableArray.re:77:6 path:+ImmutableArray
-  addValueDeclaration keepMapU ImmutableArray.re:79:6 path:+ImmutableArray
-  addValueDeclaration keepMap ImmutableArray.re:80:6 path:+ImmutableArray
-  addValueDeclaration forEachWithIndexU ImmutableArray.re:82:6 path:+ImmutableArray
-  addValueDeclaration forEachWithIndex ImmutableArray.re:83:6 path:+ImmutableArray
-  addValueDeclaration mapWithIndexU ImmutableArray.re:85:6 path:+ImmutableArray
-  addValueDeclaration mapWithIndex ImmutableArray.re:86:6 path:+ImmutableArray
-  addValueDeclaration partitionU ImmutableArray.re:88:6 path:+ImmutableArray
-  addValueDeclaration partition ImmutableArray.re:89:6 path:+ImmutableArray
-  addValueDeclaration reduceU ImmutableArray.re:91:6 path:+ImmutableArray
-  addValueDeclaration reduce ImmutableArray.re:92:6 path:+ImmutableArray
-  addValueDeclaration reduceReverseU ImmutableArray.re:94:6 path:+ImmutableArray
-  addValueDeclaration reduceReverse ImmutableArray.re:95:6 path:+ImmutableArray
-  addValueDeclaration reduceReverse2U ImmutableArray.re:97:6 path:+ImmutableArray
-  addValueDeclaration reduceReverse2 ImmutableArray.re:99:6 path:+ImmutableArray
-  addValueDeclaration someU ImmutableArray.re:102:6 path:+ImmutableArray
-  addValueDeclaration some ImmutableArray.re:103:6 path:+ImmutableArray
-  addValueDeclaration everyU ImmutableArray.re:105:6 path:+ImmutableArray
-  addValueDeclaration every ImmutableArray.re:106:6 path:+ImmutableArray
-  addValueDeclaration every2U ImmutableArray.re:108:6 path:+ImmutableArray
-  addValueDeclaration every2 ImmutableArray.re:109:6 path:+ImmutableArray
-  addValueDeclaration some2U ImmutableArray.re:111:6 path:+ImmutableArray
-  addValueDeclaration some2 ImmutableArray.re:112:6 path:+ImmutableArray
-  addValueDeclaration cmpU ImmutableArray.re:114:6 path:+ImmutableArray
-  addValueDeclaration cmp ImmutableArray.re:115:6 path:+ImmutableArray
-  addValueDeclaration eqU ImmutableArray.re:117:6 path:+ImmutableArray
-  addValueDeclaration eq ImmutableArray.re:118:6 path:+ImmutableArray
+  addValueDeclaration +fromT ImmutableArray.re:5:2 path:+ImmutableArray.Array
+  addValueDeclaration +fromTp ImmutableArray.re:6:2 path:+ImmutableArray.Array
+  addValueDeclaration +fromTT ImmutableArray.re:7:2 path:+ImmutableArray.Array
+  addValueDeclaration +toT ImmutableArray.re:8:2 path:+ImmutableArray.Array
+  addValueDeclaration +toTp ImmutableArray.re:9:2 path:+ImmutableArray.Array
+  addValueDeclaration +toT2 ImmutableArray.re:10:2 path:+ImmutableArray.Array
+  addValueDeclaration +fromArray ImmutableArray.re:14:6 path:+ImmutableArray.Array
+  addValueDeclaration +toArray ImmutableArray.re:16:6 path:+ImmutableArray.Array
+  addValueDeclaration +length ImmutableArray.re:20:6 path:+ImmutableArray.Array
+  addValueDeclaration +size ImmutableArray.re:22:6 path:+ImmutableArray.Array
+  addValueDeclaration +get ImmutableArray.re:24:6 path:+ImmutableArray.Array
+  addValueDeclaration +getExn ImmutableArray.re:26:6 path:+ImmutableArray.Array
+  addValueDeclaration +getUnsafe ImmutableArray.re:28:6 path:+ImmutableArray.Array
+  addValueDeclaration +getUndefined ImmutableArray.re:30:6 path:+ImmutableArray.Array
+  addValueDeclaration +shuffle ImmutableArray.re:32:6 path:+ImmutableArray.Array
+  addValueDeclaration +reverse ImmutableArray.re:34:6 path:+ImmutableArray.Array
+  addValueDeclaration +makeUninitialized ImmutableArray.re:36:6 path:+ImmutableArray.Array
+  addValueDeclaration +makeUninitializedUnsafe ImmutableArray.re:38:6 path:+ImmutableArray.Array
+  addValueDeclaration +make ImmutableArray.re:40:6 path:+ImmutableArray.Array
+  addValueDeclaration +range ImmutableArray.re:42:6 path:+ImmutableArray.Array
+  addValueDeclaration +rangeBy ImmutableArray.re:44:6 path:+ImmutableArray.Array
+  addValueDeclaration +makeByU ImmutableArray.re:46:6 path:+ImmutableArray.Array
+  addValueDeclaration +makeBy ImmutableArray.re:47:6 path:+ImmutableArray.Array
+  addValueDeclaration +makeByAndShuffleU ImmutableArray.re:49:6 path:+ImmutableArray.Array
+  addValueDeclaration +makeByAndShuffle ImmutableArray.re:50:6 path:+ImmutableArray.Array
+  addValueDeclaration +zip ImmutableArray.re:52:6 path:+ImmutableArray.Array
+  addValueDeclaration +zipByU ImmutableArray.re:54:6 path:+ImmutableArray.Array
+  addValueDeclaration +zipBy ImmutableArray.re:55:6 path:+ImmutableArray.Array
+  addValueDeclaration +unzip ImmutableArray.re:57:6 path:+ImmutableArray.Array
+  addValueDeclaration +concat ImmutableArray.re:59:6 path:+ImmutableArray.Array
+  addValueDeclaration +concatMany ImmutableArray.re:61:6 path:+ImmutableArray.Array
+  addValueDeclaration +slice ImmutableArray.re:63:6 path:+ImmutableArray.Array
+  addValueDeclaration +sliceToEnd ImmutableArray.re:66:6 path:+ImmutableArray.Array
+  addValueDeclaration +copy ImmutableArray.re:68:6 path:+ImmutableArray.Array
+  addValueDeclaration +forEachU ImmutableArray.re:70:6 path:+ImmutableArray.Array
+  addValueDeclaration +forEach ImmutableArray.re:71:6 path:+ImmutableArray.Array
+  addValueDeclaration +mapU ImmutableArray.re:73:6 path:+ImmutableArray.Array
+  addValueDeclaration +map ImmutableArray.re:74:6 path:+ImmutableArray.Array
+  addValueDeclaration +keepWithIndexU ImmutableArray.re:76:6 path:+ImmutableArray.Array
+  addValueDeclaration +keepWithIndex ImmutableArray.re:77:6 path:+ImmutableArray.Array
+  addValueDeclaration +keepMapU ImmutableArray.re:79:6 path:+ImmutableArray.Array
+  addValueDeclaration +keepMap ImmutableArray.re:80:6 path:+ImmutableArray.Array
+  addValueDeclaration +forEachWithIndexU ImmutableArray.re:82:6 path:+ImmutableArray.Array
+  addValueDeclaration +forEachWithIndex ImmutableArray.re:83:6 path:+ImmutableArray.Array
+  addValueDeclaration +mapWithIndexU ImmutableArray.re:85:6 path:+ImmutableArray.Array
+  addValueDeclaration +mapWithIndex ImmutableArray.re:86:6 path:+ImmutableArray.Array
+  addValueDeclaration +partitionU ImmutableArray.re:88:6 path:+ImmutableArray.Array
+  addValueDeclaration +partition ImmutableArray.re:89:6 path:+ImmutableArray.Array
+  addValueDeclaration +reduceU ImmutableArray.re:91:6 path:+ImmutableArray.Array
+  addValueDeclaration +reduce ImmutableArray.re:92:6 path:+ImmutableArray.Array
+  addValueDeclaration +reduceReverseU ImmutableArray.re:94:6 path:+ImmutableArray.Array
+  addValueDeclaration +reduceReverse ImmutableArray.re:95:6 path:+ImmutableArray.Array
+  addValueDeclaration +reduceReverse2U ImmutableArray.re:97:6 path:+ImmutableArray.Array
+  addValueDeclaration +reduceReverse2 ImmutableArray.re:99:6 path:+ImmutableArray.Array
+  addValueDeclaration +someU ImmutableArray.re:102:6 path:+ImmutableArray.Array
+  addValueDeclaration +some ImmutableArray.re:103:6 path:+ImmutableArray.Array
+  addValueDeclaration +everyU ImmutableArray.re:105:6 path:+ImmutableArray.Array
+  addValueDeclaration +every ImmutableArray.re:106:6 path:+ImmutableArray.Array
+  addValueDeclaration +every2U ImmutableArray.re:108:6 path:+ImmutableArray.Array
+  addValueDeclaration +every2 ImmutableArray.re:109:6 path:+ImmutableArray.Array
+  addValueDeclaration +some2U ImmutableArray.re:111:6 path:+ImmutableArray.Array
+  addValueDeclaration +some2 ImmutableArray.re:112:6 path:+ImmutableArray.Array
+  addValueDeclaration +cmpU ImmutableArray.re:114:6 path:+ImmutableArray.Array
+  addValueDeclaration +cmp ImmutableArray.re:115:6 path:+ImmutableArray.Array
+  addValueDeclaration +eqU ImmutableArray.re:117:6 path:+ImmutableArray.Array
+  addValueDeclaration +eq ImmutableArray.re:118:6 path:+ImmutableArray.Array
+  addValueDeclaration +fromT ImmutableArray.re:5:2 path:+ImmutableArray
+  addValueDeclaration +fromTp ImmutableArray.re:6:2 path:+ImmutableArray
+  addValueDeclaration +fromTT ImmutableArray.re:7:2 path:+ImmutableArray
+  addValueDeclaration +toT ImmutableArray.re:8:2 path:+ImmutableArray
+  addValueDeclaration +toTp ImmutableArray.re:9:2 path:+ImmutableArray
+  addValueDeclaration +toT2 ImmutableArray.re:10:2 path:+ImmutableArray
+  addValueDeclaration +fromArray ImmutableArray.re:14:6 path:+ImmutableArray
+  addValueDeclaration +toArray ImmutableArray.re:16:6 path:+ImmutableArray
+  addValueDeclaration +length ImmutableArray.re:20:6 path:+ImmutableArray
+  addValueDeclaration +size ImmutableArray.re:22:6 path:+ImmutableArray
+  addValueDeclaration +get ImmutableArray.re:24:6 path:+ImmutableArray
+  addValueDeclaration +getExn ImmutableArray.re:26:6 path:+ImmutableArray
+  addValueDeclaration +getUnsafe ImmutableArray.re:28:6 path:+ImmutableArray
+  addValueDeclaration +getUndefined ImmutableArray.re:30:6 path:+ImmutableArray
+  addValueDeclaration +shuffle ImmutableArray.re:32:6 path:+ImmutableArray
+  addValueDeclaration +reverse ImmutableArray.re:34:6 path:+ImmutableArray
+  addValueDeclaration +makeUninitialized ImmutableArray.re:36:6 path:+ImmutableArray
+  addValueDeclaration +makeUninitializedUnsafe ImmutableArray.re:38:6 path:+ImmutableArray
+  addValueDeclaration +make ImmutableArray.re:40:6 path:+ImmutableArray
+  addValueDeclaration +range ImmutableArray.re:42:6 path:+ImmutableArray
+  addValueDeclaration +rangeBy ImmutableArray.re:44:6 path:+ImmutableArray
+  addValueDeclaration +makeByU ImmutableArray.re:46:6 path:+ImmutableArray
+  addValueDeclaration +makeBy ImmutableArray.re:47:6 path:+ImmutableArray
+  addValueDeclaration +makeByAndShuffleU ImmutableArray.re:49:6 path:+ImmutableArray
+  addValueDeclaration +makeByAndShuffle ImmutableArray.re:50:6 path:+ImmutableArray
+  addValueDeclaration +zip ImmutableArray.re:52:6 path:+ImmutableArray
+  addValueDeclaration +zipByU ImmutableArray.re:54:6 path:+ImmutableArray
+  addValueDeclaration +zipBy ImmutableArray.re:55:6 path:+ImmutableArray
+  addValueDeclaration +unzip ImmutableArray.re:57:6 path:+ImmutableArray
+  addValueDeclaration +concat ImmutableArray.re:59:6 path:+ImmutableArray
+  addValueDeclaration +concatMany ImmutableArray.re:61:6 path:+ImmutableArray
+  addValueDeclaration +slice ImmutableArray.re:63:6 path:+ImmutableArray
+  addValueDeclaration +sliceToEnd ImmutableArray.re:66:6 path:+ImmutableArray
+  addValueDeclaration +copy ImmutableArray.re:68:6 path:+ImmutableArray
+  addValueDeclaration +forEachU ImmutableArray.re:70:6 path:+ImmutableArray
+  addValueDeclaration +forEach ImmutableArray.re:71:6 path:+ImmutableArray
+  addValueDeclaration +mapU ImmutableArray.re:73:6 path:+ImmutableArray
+  addValueDeclaration +map ImmutableArray.re:74:6 path:+ImmutableArray
+  addValueDeclaration +keepWithIndexU ImmutableArray.re:76:6 path:+ImmutableArray
+  addValueDeclaration +keepWithIndex ImmutableArray.re:77:6 path:+ImmutableArray
+  addValueDeclaration +keepMapU ImmutableArray.re:79:6 path:+ImmutableArray
+  addValueDeclaration +keepMap ImmutableArray.re:80:6 path:+ImmutableArray
+  addValueDeclaration +forEachWithIndexU ImmutableArray.re:82:6 path:+ImmutableArray
+  addValueDeclaration +forEachWithIndex ImmutableArray.re:83:6 path:+ImmutableArray
+  addValueDeclaration +mapWithIndexU ImmutableArray.re:85:6 path:+ImmutableArray
+  addValueDeclaration +mapWithIndex ImmutableArray.re:86:6 path:+ImmutableArray
+  addValueDeclaration +partitionU ImmutableArray.re:88:6 path:+ImmutableArray
+  addValueDeclaration +partition ImmutableArray.re:89:6 path:+ImmutableArray
+  addValueDeclaration +reduceU ImmutableArray.re:91:6 path:+ImmutableArray
+  addValueDeclaration +reduce ImmutableArray.re:92:6 path:+ImmutableArray
+  addValueDeclaration +reduceReverseU ImmutableArray.re:94:6 path:+ImmutableArray
+  addValueDeclaration +reduceReverse ImmutableArray.re:95:6 path:+ImmutableArray
+  addValueDeclaration +reduceReverse2U ImmutableArray.re:97:6 path:+ImmutableArray
+  addValueDeclaration +reduceReverse2 ImmutableArray.re:99:6 path:+ImmutableArray
+  addValueDeclaration +someU ImmutableArray.re:102:6 path:+ImmutableArray
+  addValueDeclaration +some ImmutableArray.re:103:6 path:+ImmutableArray
+  addValueDeclaration +everyU ImmutableArray.re:105:6 path:+ImmutableArray
+  addValueDeclaration +every ImmutableArray.re:106:6 path:+ImmutableArray
+  addValueDeclaration +every2U ImmutableArray.re:108:6 path:+ImmutableArray
+  addValueDeclaration +every2 ImmutableArray.re:109:6 path:+ImmutableArray
+  addValueDeclaration +some2U ImmutableArray.re:111:6 path:+ImmutableArray
+  addValueDeclaration +some2 ImmutableArray.re:112:6 path:+ImmutableArray
+  addValueDeclaration +cmpU ImmutableArray.re:114:6 path:+ImmutableArray
+  addValueDeclaration +cmp ImmutableArray.re:115:6 path:+ImmutableArray
+  addValueDeclaration +eqU ImmutableArray.re:117:6 path:+ImmutableArray
+  addValueDeclaration +eq ImmutableArray.re:118:6 path:+ImmutableArray
   addValueReference ImmutableArray.re:14:6 --> ImmutableArray.re:14:18
   addValueReference ImmutableArray.re:14:6 --> ImmutableArray.re:8:2
   addValueReference ImmutableArray.re:16:6 --> ImmutableArray.re:16:16
@@ -538,39 +538,39 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TransitiveType3.cmt
   addTypeDeclaration i TransitiveType3.re:3:2 path:+TransitiveType3.t3
   addTypeDeclaration s TransitiveType3.re:4:2 path:+TransitiveType3.t3
-  addValueDeclaration convertT3 TransitiveType3.re:8:4 path:+TransitiveType3
+  addValueDeclaration +convertT3 TransitiveType3.re:8:4 path:+TransitiveType3
   addTypeDeclaration +i TransitiveType3.re:3:2 path:+TransitiveType3.+t3
   addTypeDeclaration +s TransitiveType3.re:4:2 path:+TransitiveType3.+t3
   addValueReference TransitiveType3.re:8:4 --> TransitiveType3.re:8:17
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DynamicallyLoadedComponent.cmt
-  addValueDeclaration make DynamicallyLoadedComponent.re:2:4 path:+DynamicallyLoadedComponent
+  addValueDeclaration +make DynamicallyLoadedComponent.re:2:4 path:+DynamicallyLoadedComponent
   addValueReference DynamicallyLoadedComponent.re:2:4 --> DynamicallyLoadedComponent.re:2:13
   addValueReference DynamicallyLoadedComponent.re:2:4 --> React.re:5:0
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TransitiveType2.cmt
-  addValueDeclaration convertT2 TransitiveType2.re:7:4 path:+TransitiveType2
+  addValueDeclaration +convertT2 TransitiveType2.re:7:4 path:+TransitiveType2
   addValueReference TransitiveType2.re:7:4 --> TransitiveType2.re:7:17
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Variants.cmt
-  addValueDeclaration isWeekend Variants.re:13:4 path:+Variants
-  addValueDeclaration monday Variants.re:21:4 path:+Variants
-  addValueDeclaration saturday Variants.re:23:4 path:+Variants
-  addValueDeclaration sunday Variants.re:25:4 path:+Variants
-  addValueDeclaration onlySunday Variants.re:28:4 path:+Variants
-  addValueDeclaration swap Variants.re:31:4 path:+Variants
-  addValueDeclaration testConvert Variants.re:45:4 path:+Variants
-  addValueDeclaration fortytwoOK Variants.re:48:4 path:+Variants
-  addValueDeclaration fortytwoBAD Variants.re:52:4 path:+Variants
-  addValueDeclaration testConvert2 Variants.re:64:4 path:+Variants
-  addValueDeclaration testConvert3 Variants.re:76:4 path:+Variants
-  addValueDeclaration testConvert2to3 Variants.re:80:4 path:+Variants
-  addValueDeclaration id1 Variants.re:89:4 path:+Variants
-  addValueDeclaration id2 Variants.re:92:4 path:+Variants
+  addValueDeclaration +isWeekend Variants.re:13:4 path:+Variants
+  addValueDeclaration +monday Variants.re:21:4 path:+Variants
+  addValueDeclaration +saturday Variants.re:23:4 path:+Variants
+  addValueDeclaration +sunday Variants.re:25:4 path:+Variants
+  addValueDeclaration +onlySunday Variants.re:28:4 path:+Variants
+  addValueDeclaration +swap Variants.re:31:4 path:+Variants
+  addValueDeclaration +testConvert Variants.re:45:4 path:+Variants
+  addValueDeclaration +fortytwoOK Variants.re:48:4 path:+Variants
+  addValueDeclaration +fortytwoBAD Variants.re:52:4 path:+Variants
+  addValueDeclaration +testConvert2 Variants.re:64:4 path:+Variants
+  addValueDeclaration +testConvert3 Variants.re:76:4 path:+Variants
+  addValueDeclaration +testConvert2to3 Variants.re:80:4 path:+Variants
+  addValueDeclaration +id1 Variants.re:89:4 path:+Variants
+  addValueDeclaration +id2 Variants.re:92:4 path:+Variants
   addTypeDeclaration Type Variants.re:97:4 path:+Variants.type_
-  addValueDeclaration polyWithOpt Variants.re:100:4 path:+Variants
+  addValueDeclaration +polyWithOpt Variants.re:100:4 path:+Variants
   addTypeDeclaration Ok Variants.re:105:4 path:+Variants.result1
   addTypeDeclaration Error Variants.re:106:4 path:+Variants.result1
-  addValueDeclaration restResult1 Variants.re:115:4 path:+Variants
-  addValueDeclaration restResult2 Variants.re:118:4 path:+Variants
-  addValueDeclaration restResult3 Variants.re:121:4 path:+Variants
+  addValueDeclaration +restResult1 Variants.re:115:4 path:+Variants
+  addValueDeclaration +restResult2 Variants.re:118:4 path:+Variants
+  addValueDeclaration +restResult3 Variants.re:121:4 path:+Variants
   addValueReference Variants.re:13:4 --> Variants.re:13:17
   addValueReference Variants.re:31:4 --> Variants.re:31:11
   addValueReference Variants.re:45:4 --> Variants.re:45:19
@@ -589,20 +589,20 @@
   addValueReference Variants.re:118:4 --> Variants.re:118:19
   addValueReference Variants.re:121:4 --> Variants.re:121:19
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Uncurried.cmt
-  addValueDeclaration uncurried0 Uncurried.re:14:4 path:+Uncurried
-  addValueDeclaration uncurried1 Uncurried.re:17:4 path:+Uncurried
-  addValueDeclaration uncurried2 Uncurried.re:20:4 path:+Uncurried
-  addValueDeclaration uncurried3 Uncurried.re:23:4 path:+Uncurried
-  addValueDeclaration curried3 Uncurried.re:27:4 path:+Uncurried
-  addValueDeclaration callback Uncurried.re:30:4 path:+Uncurried
+  addValueDeclaration +uncurried0 Uncurried.re:14:4 path:+Uncurried
+  addValueDeclaration +uncurried1 Uncurried.re:17:4 path:+Uncurried
+  addValueDeclaration +uncurried2 Uncurried.re:20:4 path:+Uncurried
+  addValueDeclaration +uncurried3 Uncurried.re:23:4 path:+Uncurried
+  addValueDeclaration +curried3 Uncurried.re:27:4 path:+Uncurried
+  addValueDeclaration +callback Uncurried.re:30:4 path:+Uncurried
   addTypeDeclaration login Uncurried.re:32:13 path:+Uncurried.auth
   addTypeDeclaration loginU Uncurried.re:33:14 path:+Uncurried.authU
-  addValueDeclaration callback2 Uncurried.re:36:4 path:+Uncurried
-  addValueDeclaration callback2U Uncurried.re:39:4 path:+Uncurried
-  addValueDeclaration sumU Uncurried.re:42:4 path:+Uncurried
-  addValueDeclaration sumU2 Uncurried.re:48:4 path:+Uncurried
-  addValueDeclaration sumCurried Uncurried.re:55:4 path:+Uncurried
-  addValueDeclaration sumLblCurried Uncurried.re:63:4 path:+Uncurried
+  addValueDeclaration +callback2 Uncurried.re:36:4 path:+Uncurried
+  addValueDeclaration +callback2U Uncurried.re:39:4 path:+Uncurried
+  addValueDeclaration +sumU Uncurried.re:42:4 path:+Uncurried
+  addValueDeclaration +sumU2 Uncurried.re:48:4 path:+Uncurried
+  addValueDeclaration +sumCurried Uncurried.re:55:4 path:+Uncurried
+  addValueDeclaration +sumLblCurried Uncurried.re:63:4 path:+Uncurried
   addValueReference Uncurried.re:17:4 --> Uncurried.re:17:20
   addValueReference Uncurried.re:20:4 --> Uncurried.re:20:20
   addValueReference Uncurried.re:20:4 --> Uncurried.re:20:23
@@ -635,63 +635,63 @@
   addValueReference Uncurried.re:63:4 --> Uncurried.re:63:21
   addValueReference Uncurried.re:63:4 --> Uncurried.re:63:33
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TestEmitInnerModules.cmt
-  addValueDeclaration x TestEmitInnerModules.re:3:6 path:+TestEmitInnerModules.Inner
-  addValueDeclaration y TestEmitInnerModules.re:5:6 path:+TestEmitInnerModules.Inner
-  addValueDeclaration y TestEmitInnerModules.re:12:10 path:+TestEmitInnerModules.Outer.Medium.Inner
+  addValueDeclaration +x TestEmitInnerModules.re:3:6 path:+TestEmitInnerModules.Inner
+  addValueDeclaration +y TestEmitInnerModules.re:5:6 path:+TestEmitInnerModules.Inner
+  addValueDeclaration +y TestEmitInnerModules.re:12:10 path:+TestEmitInnerModules.Outer.Medium.Inner
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/NestedModules.cmt
-  addValueDeclaration notNested NestedModules.re:2:4 path:+NestedModules
-  addValueDeclaration theAnswer NestedModules.re:6:6 path:+NestedModules.Universe
-  addValueDeclaration notExported NestedModules.re:8:6 path:+NestedModules.Universe
-  addValueDeclaration x NestedModules.re:14:8 path:+NestedModules.Universe.Nested2
-  addValueDeclaration nested2Value NestedModules.re:17:8 path:+NestedModules.Universe.Nested2
-  addValueDeclaration y NestedModules.re:19:8 path:+NestedModules.Universe.Nested2
-  addValueDeclaration x NestedModules.re:25:10 path:+NestedModules.Universe.Nested2.Nested3
-  addValueDeclaration y NestedModules.re:26:10 path:+NestedModules.Universe.Nested2.Nested3
-  addValueDeclaration z NestedModules.re:27:10 path:+NestedModules.Universe.Nested2.Nested3
-  addValueDeclaration w NestedModules.re:28:10 path:+NestedModules.Universe.Nested2.Nested3
-  addValueDeclaration nested3Value NestedModules.re:34:10 path:+NestedModules.Universe.Nested2.Nested3
-  addValueDeclaration nested3Function NestedModules.re:37:10 path:+NestedModules.Universe.Nested2.Nested3
-  addValueDeclaration nested2Function NestedModules.re:41:8 path:+NestedModules.Universe.Nested2
+  addValueDeclaration +notNested NestedModules.re:2:4 path:+NestedModules
+  addValueDeclaration +theAnswer NestedModules.re:6:6 path:+NestedModules.Universe
+  addValueDeclaration +notExported NestedModules.re:8:6 path:+NestedModules.Universe
+  addValueDeclaration +x NestedModules.re:14:8 path:+NestedModules.Universe.Nested2
+  addValueDeclaration +nested2Value NestedModules.re:17:8 path:+NestedModules.Universe.Nested2
+  addValueDeclaration +y NestedModules.re:19:8 path:+NestedModules.Universe.Nested2
+  addValueDeclaration +x NestedModules.re:25:10 path:+NestedModules.Universe.Nested2.Nested3
+  addValueDeclaration +y NestedModules.re:26:10 path:+NestedModules.Universe.Nested2.Nested3
+  addValueDeclaration +z NestedModules.re:27:10 path:+NestedModules.Universe.Nested2.Nested3
+  addValueDeclaration +w NestedModules.re:28:10 path:+NestedModules.Universe.Nested2.Nested3
+  addValueDeclaration +nested3Value NestedModules.re:34:10 path:+NestedModules.Universe.Nested2.Nested3
+  addValueDeclaration +nested3Function NestedModules.re:37:10 path:+NestedModules.Universe.Nested2.Nested3
+  addValueDeclaration +nested2Function NestedModules.re:41:8 path:+NestedModules.Universe.Nested2
   addTypeDeclaration A NestedModules.re:46:6 path:+NestedModules.Universe.variant
   addTypeDeclaration B NestedModules.re:47:6 path:+NestedModules.Universe.variant
-  addValueDeclaration someString NestedModules.re:50:6 path:+NestedModules.Universe
+  addValueDeclaration +someString NestedModules.re:50:6 path:+NestedModules.Universe
   addValueReference NestedModules.re:37:10 --> NestedModules.re:37:29
   addValueReference NestedModules.re:41:8 --> NestedModules.re:41:27
   addTypeDeclaration +A NestedModules.re:46:6 path:+NestedModules.Universe.+variant
   addTypeDeclaration +B NestedModules.re:47:6 path:+NestedModules.Universe.+variant
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Shadow.cmt
-  addValueDeclaration test Shadow.re:2:4 path:+Shadow
-  addValueDeclaration test Shadow.re:5:4 path:+Shadow
-  addValueDeclaration test Shadow.re:11:6 path:+Shadow.M
+  addValueDeclaration +test Shadow.re:2:4 path:+Shadow
+  addValueDeclaration +test Shadow.re:5:4 path:+Shadow
+  addValueDeclaration +test Shadow.re:11:6 path:+Shadow.M
   addValueDeclaration +test Shadow.re:9:6 path:+Shadow.M
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ModuleAliases2.cmt
   addTypeDeclaration x ModuleAliases2.re:3:2 path:+ModuleAliases2.record
   addTypeDeclaration y ModuleAliases2.re:4:2 path:+ModuleAliases2.record
   addTypeDeclaration outer ModuleAliases2.re:9:16 path:+ModuleAliases2.Outer.outer
   addTypeDeclaration inner ModuleAliases2.re:13:18 path:+ModuleAliases2.Outer.Inner.inner
-  addValueDeclaration q ModuleAliases2.re:21:4 path:+ModuleAliases2
+  addValueDeclaration +q ModuleAliases2.re:21:4 path:+ModuleAliases2
   addTypeDeclaration +x ModuleAliases2.re:3:2 path:+ModuleAliases2.+record
   addTypeDeclaration +y ModuleAliases2.re:4:2 path:+ModuleAliases2.+record
   addTypeDeclaration +outer ModuleAliases2.re:9:16 path:+ModuleAliases2.Outer.+outer
   addTypeDeclaration +inner ModuleAliases2.re:13:18 path:+ModuleAliases2.Outer.Inner.+inner
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadValueTest.cmt
-  addValueDeclaration valueAlive DeadValueTest.re:1:4 path:+DeadValueTest
-  addValueDeclaration valueDead DeadValueTest.re:2:4 path:+DeadValueTest
-  addValueDeclaration valueOnlyInImplementation DeadValueTest.re:4:4 path:+DeadValueTest
+  addValueDeclaration +valueAlive DeadValueTest.re:1:4 path:+DeadValueTest
+  addValueDeclaration +valueDead DeadValueTest.re:2:4 path:+DeadValueTest
+  addValueDeclaration +valueOnlyInImplementation DeadValueTest.re:4:4 path:+DeadValueTest
   addValueReference DeadValueTest.rei:1:0 --> DeadValueTest.re:1:4
   addValueReference DeadValueTest.rei:2:0 --> DeadValueTest.re:2:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Tuples.cmt
-  addValueDeclaration testTuple Tuples.re:4:4 path:+Tuples
-  addValueDeclaration origin Tuples.re:10:4 path:+Tuples
-  addValueDeclaration computeArea Tuples.re:13:4 path:+Tuples
-  addValueDeclaration computeAreaWithIdent Tuples.re:17:4 path:+Tuples
-  addValueDeclaration computeAreaNoConverters Tuples.re:21:4 path:+Tuples
-  addValueDeclaration coord2d Tuples.re:24:4 path:+Tuples
+  addValueDeclaration +testTuple Tuples.re:4:4 path:+Tuples
+  addValueDeclaration +origin Tuples.re:10:4 path:+Tuples
+  addValueDeclaration +computeArea Tuples.re:13:4 path:+Tuples
+  addValueDeclaration +computeAreaWithIdent Tuples.re:17:4 path:+Tuples
+  addValueDeclaration +computeAreaNoConverters Tuples.re:21:4 path:+Tuples
+  addValueDeclaration +coord2d Tuples.re:24:4 path:+Tuples
   addTypeDeclaration name Tuples.re:31:2 path:+Tuples.person
   addTypeDeclaration age Tuples.re:32:2 path:+Tuples.person
-  addValueDeclaration getFirstName Tuples.re:39:4 path:+Tuples
-  addValueDeclaration marry Tuples.re:42:4 path:+Tuples
-  addValueDeclaration changeSecondAge Tuples.re:45:4 path:+Tuples
+  addValueDeclaration +getFirstName Tuples.re:39:4 path:+Tuples
+  addValueDeclaration +marry Tuples.re:42:4 path:+Tuples
+  addValueDeclaration +changeSecondAge Tuples.re:45:4 path:+Tuples
   addValueReference Tuples.re:4:4 --> Tuples.re:4:18
   addValueReference Tuples.re:4:4 --> Tuples.re:4:21
   addValueReference Tuples.re:13:4 --> Tuples.re:13:20
@@ -717,24 +717,24 @@
   addValueReference Tuples.re:45:4 --> Tuples.re:45:31
   addValueReference Tuples.re:45:4 --> Tuples.re:45:31
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TransitiveType1.cmt
-  addValueDeclaration convert TransitiveType1.re:2:4 path:+TransitiveType1
-  addValueDeclaration convertAlias TransitiveType1.re:5:4 path:+TransitiveType1
+  addValueDeclaration +convert TransitiveType1.re:2:4 path:+TransitiveType1
+  addValueDeclaration +convertAlias TransitiveType1.re:5:4 path:+TransitiveType1
   addValueReference TransitiveType1.re:2:4 --> TransitiveType1.re:2:15
   addValueReference TransitiveType1.re:5:4 --> TransitiveType1.re:5:20
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TypeParams2.cmt
   addTypeDeclaration id TypeParams2.re:2:13 path:+TypeParams2.item
-  addValueDeclaration exportSomething TypeParams2.re:10:4 path:+TypeParams2
+  addValueDeclaration +exportSomething TypeParams2.re:10:4 path:+TypeParams2
   addTypeDeclaration +id TypeParams2.re:2:13 path:+TypeParams2.+item
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/FirstClassModules.cmt
-  addValueDeclaration y FirstClassModules.re:17:6 path:+FirstClassModules.M
-  addValueDeclaration k FirstClassModules.re:21:8 path:+FirstClassModules.M.InnerModule2
-  addValueDeclaration k3 FirstClassModules.re:25:8 path:+FirstClassModules.M.InnerModule3
-  addValueDeclaration u FirstClassModules.re:30:8 path:+FirstClassModules.M.Z
-  addValueDeclaration f FirstClassModules.re:33:2 path:+FirstClassModules.M
-  addValueDeclaration x FirstClassModules.re:34:6 path:+FirstClassModules.M
-  addValueDeclaration firstClassModule FirstClassModules.re:41:4 path:+FirstClassModules
-  addValueDeclaration testConvert FirstClassModules.re:44:4 path:+FirstClassModules
-  addValueDeclaration someFunctorAsFunction FirstClassModules.re:53:4 path:+FirstClassModules
+  addValueDeclaration +y FirstClassModules.re:17:6 path:+FirstClassModules.M
+  addValueDeclaration +k FirstClassModules.re:21:8 path:+FirstClassModules.M.InnerModule2
+  addValueDeclaration +k3 FirstClassModules.re:25:8 path:+FirstClassModules.M.InnerModule3
+  addValueDeclaration +u FirstClassModules.re:30:8 path:+FirstClassModules.M.Z
+  addValueDeclaration +f FirstClassModules.re:33:2 path:+FirstClassModules.M
+  addValueDeclaration +x FirstClassModules.re:34:6 path:+FirstClassModules.M
+  addValueDeclaration +firstClassModule FirstClassModules.re:41:4 path:+FirstClassModules
+  addValueDeclaration +testConvert FirstClassModules.re:44:4 path:+FirstClassModules
+  addValueDeclaration +someFunctorAsFunction FirstClassModules.re:53:4 path:+FirstClassModules
   addValueReference FirstClassModules.re:25:8 --> FirstClassModules.re:25:13
   addValueReference FirstClassModules.re:44:4 --> FirstClassModules.re:44:19
   addValueDeclaration +ww FirstClassModules.re:49:6 path:+FirstClassModules.SomeFunctor
@@ -750,42 +750,42 @@
   addValueReference FirstClassModules.re:14:2 --> FirstClassModules.re:17:6
   addValueReference FirstClassModules.re:46:20 --> FirstClassModules.re:49:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadMl.cmt
-  addValueDeclaration thisSpansSeveralLines DeadMl.ml:3:8 path:+DeadMl.QQ
-  addValueDeclaration thisIsInInterface DeadMl.ml:9:2 path:+DeadMl.AA
-  addValueDeclaration thisHasSemicolons DeadMl.ml:15:4 path:+DeadMl
+  addValueDeclaration +thisSpansSeveralLines DeadMl.ml:3:8 path:+DeadMl.QQ
+  addValueDeclaration +thisIsInInterface DeadMl.ml:9:2 path:+DeadMl.AA
+  addValueDeclaration +thisHasSemicolons DeadMl.ml:15:4 path:+DeadMl
   addTypeDeclaration DeadA DeadMl.ml:17:18 path:+DeadMl.thisIsDead
   addTypeDeclaration DeadB DeadMl.ml:17:26 path:+DeadMl.thisIsDead
-  addValueDeclaration version DeadMl.ml:26:6 path:+DeadMl.Bs_version
-  addValueDeclaration header DeadMl.ml:26:27 path:+DeadMl.Bs_version
-  addValueDeclaration package_name DeadMl.ml:26:47 path:+DeadMl.Bs_version
+  addValueDeclaration +version DeadMl.ml:26:6 path:+DeadMl.Bs_version
+  addValueDeclaration +header DeadMl.ml:26:27 path:+DeadMl.Bs_version
+  addValueDeclaration +package_name DeadMl.ml:26:47 path:+DeadMl.Bs_version
   addTypeDeclaration Lfunction DeadMl.ml:35:2 path:+DeadMl.l
   addTypeDeclaration module_name DeadMl.ml:41:2 path:+DeadMl.module_info
   addTypeDeclaration case DeadMl.ml:42:2 path:+DeadMl.module_info
-  addValueDeclaration map_split_opt DeadMl.ml:45:8 path:+DeadMl
-  addValueDeclaration inline_threshold DeadMl.ml:56:4 path:+DeadMl
-  addValueDeclaration dead1 DeadMl.ml:59:6 path:+DeadMl.Scope
-  addValueDeclaration deadInner1 DeadMl.ml:62:8 path:+DeadMl.Scope.Inner1
-  addValueDeclaration liveInner2 DeadMl.ml:66:8 path:+DeadMl.Scope.Inner1
-  addValueDeclaration dead2 DeadMl.ml:69:6 path:+DeadMl.Scope
-  addValueDeclaration liveInner3 DeadMl.ml:74:8 path:+DeadMl.Scope.Inner2
-  addValueDeclaration live3 DeadMl.ml:77:6 path:+DeadMl.Scope
-  addValueDeclaration dead4 DeadMl.ml:80:4 path:+DeadMl
-  addValueDeclaration live5 DeadMl.ml:82:4 path:+DeadMl
-  addValueDeclaration dead5 DeadMl.ml:85:4 path:+DeadMl
-  addValueDeclaration live6 DeadMl.ml:87:4 path:+DeadMl
-  addValueDeclaration dead7 DeadMl.ml:90:4 path:+DeadMl
-  addValueDeclaration dead8 DeadMl.ml:94:2 path:+DeadMl.WithSignature
-  addValueDeclaration live9 DeadMl.ml:96:2 path:+DeadMl.WithSignature
-  addValueDeclaration dead10 DeadMl.ml:99:2 path:+DeadMl.WithSignature
-  addValueDeclaration live11 DeadMl.ml:103:2 path:+DeadMl.WithSignature
+  addValueDeclaration +map_split_opt DeadMl.ml:45:8 path:+DeadMl
+  addValueDeclaration +inline_threshold DeadMl.ml:56:4 path:+DeadMl
+  addValueDeclaration +dead1 DeadMl.ml:59:6 path:+DeadMl.Scope
+  addValueDeclaration +deadInner1 DeadMl.ml:62:8 path:+DeadMl.Scope.Inner1
+  addValueDeclaration +liveInner2 DeadMl.ml:66:8 path:+DeadMl.Scope.Inner1
+  addValueDeclaration +dead2 DeadMl.ml:69:6 path:+DeadMl.Scope
+  addValueDeclaration +liveInner3 DeadMl.ml:74:8 path:+DeadMl.Scope.Inner2
+  addValueDeclaration +live3 DeadMl.ml:77:6 path:+DeadMl.Scope
+  addValueDeclaration +dead4 DeadMl.ml:80:4 path:+DeadMl
+  addValueDeclaration +live5 DeadMl.ml:82:4 path:+DeadMl
+  addValueDeclaration +dead5 DeadMl.ml:85:4 path:+DeadMl
+  addValueDeclaration +live6 DeadMl.ml:87:4 path:+DeadMl
+  addValueDeclaration +dead7 DeadMl.ml:90:4 path:+DeadMl
+  addValueDeclaration +dead8 DeadMl.ml:94:2 path:+DeadMl.WithSignature
+  addValueDeclaration +live9 DeadMl.ml:96:2 path:+DeadMl.WithSignature
+  addValueDeclaration +dead10 DeadMl.ml:99:2 path:+DeadMl.WithSignature
+  addValueDeclaration +live11 DeadMl.ml:103:2 path:+DeadMl.WithSignature
   addValueReference DeadMl.ml:3:8 --> DeadMl.ml:4:11
   addValueReference DeadMl.ml:3:8 --> DeadMl.ml:4:20
   addValueDeclaration +thisIsInInterface DeadMl.ml:12:6 path:+DeadMl.AA
   addValueReference DeadMl.ml:12:6 --> DeadMl.ml:12:24
   addTypeDeclaration +DeadA DeadMl.ml:17:18 path:+DeadMl.+thisIsDead
   addTypeDeclaration +DeadB DeadMl.ml:17:26 path:+DeadMl.+thisIsDead
-  addValueDeclaration _ DeadMl.ml:21:2 path:+DeadMl
-  addValueDeclaration _ DeadMl.ml:22:2 path:+DeadMl
+  addValueDeclaration +_ DeadMl.ml:21:2 path:+DeadMl
+  addValueDeclaration +_ DeadMl.ml:22:2 path:+DeadMl
   addValueDeclaration +version DeadMl.ml:29:8 path:+DeadMl.Bs_version
   addValueDeclaration +header DeadMl.ml:30:8 path:+DeadMl.Bs_version
   addValueDeclaration +package_name DeadMl.ml:31:8 path:+DeadMl.Bs_version
@@ -820,46 +820,46 @@
   addValueReference DeadMl.ml:103:2 --> DeadMl.ml:109:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportMyBanner.cmt
   addTypeDeclaration text ImportMyBanner.re:6:16 path:+ImportMyBanner.message
-  addValueDeclaration make ImportMyBanner.re:8:0 path:+ImportMyBanner
-  addValueDeclaration make ImportMyBanner.re:19:4 path:+ImportMyBanner
+  addValueDeclaration +make ImportMyBanner.re:8:0 path:+ImportMyBanner
+  addValueDeclaration +make ImportMyBanner.re:19:4 path:+ImportMyBanner
   addTypeDeclaration +text ImportMyBanner.re:6:16 path:+ImportMyBanner.+message
   addValueReference ImportMyBanner.re:19:4 --> ImportMyBanner.re:8:0
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TypeParams3.cmt
-  addValueDeclaration test TypeParams3.re:2:4 path:+TypeParams3
-  addValueDeclaration test2 TypeParams3.re:5:4 path:+TypeParams3
+  addValueDeclaration +test TypeParams3.re:2:4 path:+TypeParams3
+  addValueDeclaration +test2 TypeParams3.re:5:4 path:+TypeParams3
   addValueReference TypeParams3.re:2:4 --> TypeParams3.re:2:12
   addValueReference TypeParams3.re:5:4 --> TypeParams3.re:5:13
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/IgnoreInterface.cmt
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadValueTest.cmti
-  addValueDeclaration valueAlive DeadValueTest.rei:1:0 path:DeadValueTest
-  addValueDeclaration valueDead DeadValueTest.rei:2:0 path:DeadValueTest
+  addValueDeclaration +valueAlive DeadValueTest.rei:1:0 path:DeadValueTest
+  addValueDeclaration +valueDead DeadValueTest.rei:2:0 path:DeadValueTest
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/IgnoreInterface.cmti
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TypeParams1.cmt
-  addValueDeclaration exportSomething TypeParams1.re:4:4 path:+TypeParams1
+  addValueDeclaration +exportSomething TypeParams1.re:4:4 path:+TypeParams1
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TestModuleAliases.cmt
-  addValueDeclaration testInner1 TestModuleAliases.re:32:4 path:+TestModuleAliases
-  addValueDeclaration testInner1Expanded TestModuleAliases.re:35:4 path:+TestModuleAliases
-  addValueDeclaration testInner2 TestModuleAliases.re:38:4 path:+TestModuleAliases
-  addValueDeclaration testInner2Expanded TestModuleAliases.re:41:4 path:+TestModuleAliases
+  addValueDeclaration +testInner1 TestModuleAliases.re:32:4 path:+TestModuleAliases
+  addValueDeclaration +testInner1Expanded TestModuleAliases.re:35:4 path:+TestModuleAliases
+  addValueDeclaration +testInner2 TestModuleAliases.re:38:4 path:+TestModuleAliases
+  addValueDeclaration +testInner2Expanded TestModuleAliases.re:41:4 path:+TestModuleAliases
   addValueReference TestModuleAliases.re:32:4 --> TestModuleAliases.re:32:18
   addValueReference TestModuleAliases.re:35:4 --> TestModuleAliases.re:35:26
   addValueReference TestModuleAliases.re:38:4 --> TestModuleAliases.re:38:18
   addValueReference TestModuleAliases.re:41:4 --> TestModuleAliases.re:41:26
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Opaque.cmt
   addTypeDeclaration A Opaque.re:3:4 path:+Opaque.opaqueFromRecords
-  addValueDeclaration noConversion Opaque.re:6:4 path:+Opaque
-  addValueDeclaration testConvertNestedRecordFromOtherFile Opaque.re:12:4 path:+Opaque
+  addValueDeclaration +noConversion Opaque.re:6:4 path:+Opaque
+  addValueDeclaration +testConvertNestedRecordFromOtherFile Opaque.re:12:4 path:+Opaque
   addTypeDeclaration +A Opaque.re:3:4 path:+Opaque.+opaqueFromRecords
   addValueReference Opaque.re:6:4 --> Opaque.re:6:20
   addValueReference Opaque.re:12:4 --> Opaque.re:12:44
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ManyComponents.cmt
-  addValueDeclaration someValueSoModuleOffsetsAreShifted ManyComponents.re:4:6 path:+ManyComponents.InnerComponent
-  addValueDeclaration component ManyComponents.re:6:6 path:+ManyComponents.InnerComponent
-  addValueDeclaration make ManyComponents.re:9:6 path:+ManyComponents.InnerComponent
-  addValueDeclaration component ManyComponents.re:16:6 path:+ManyComponents.ManyProps
-  addValueDeclaration make ManyComponents.re:19:6 path:+ManyComponents.ManyProps
-  addValueDeclaration component ManyComponents.re:36:4 path:+ManyComponents
-  addValueDeclaration make ManyComponents.re:39:4 path:+ManyComponents
+  addValueDeclaration +someValueSoModuleOffsetsAreShifted ManyComponents.re:4:6 path:+ManyComponents.InnerComponent
+  addValueDeclaration +component ManyComponents.re:6:6 path:+ManyComponents.InnerComponent
+  addValueDeclaration +make ManyComponents.re:9:6 path:+ManyComponents.InnerComponent
+  addValueDeclaration +component ManyComponents.re:16:6 path:+ManyComponents.ManyProps
+  addValueDeclaration +make ManyComponents.re:19:6 path:+ManyComponents.ManyProps
+  addValueDeclaration +component ManyComponents.re:36:4 path:+ManyComponents
+  addValueDeclaration +make ManyComponents.re:39:4 path:+ManyComponents
   addValueReference ManyComponents.re:6:6 --> ReasonReact.rei:153:0
   addValueReference ManyComponents.re:9:6 --> ReasonReact.rei:17:0
   addValueReference ManyComponents.re:9:6 --> ReactDOMRe.re:2105:0
@@ -877,30 +877,30 @@
   addValueReference ManyComponents.re:39:4 --> ReactDOMRe.re:2105:0
   addValueReference ManyComponents.re:39:4 --> ManyComponents.re:36:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ErrorHandler.cmti
-  addValueDeclaration notify ErrorHandler.rei:5:32 path:ErrorHandler.Make
-  addValueDeclaration x ErrorHandler.rei:7:0 path:ErrorHandler
+  addValueDeclaration +notify ErrorHandler.rei:5:32 path:ErrorHandler.Make
+  addValueDeclaration +x ErrorHandler.rei:7:0 path:ErrorHandler
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/VariantsWithPayload.cmt
   addTypeDeclaration x VariantsWithPayload.re:2:2 path:+VariantsWithPayload.payload
   addTypeDeclaration y VariantsWithPayload.re:3:2 path:+VariantsWithPayload.payload
-  addValueDeclaration testWithPayload VariantsWithPayload.re:16:4 path:+VariantsWithPayload
-  addValueDeclaration printVariantWithPayload VariantsWithPayload.re:19:4 path:+VariantsWithPayload
-  addValueDeclaration testManyPayloads VariantsWithPayload.re:38:4 path:+VariantsWithPayload
-  addValueDeclaration printManyPayloads VariantsWithPayload.re:41:4 path:+VariantsWithPayload
+  addValueDeclaration +testWithPayload VariantsWithPayload.re:16:4 path:+VariantsWithPayload
+  addValueDeclaration +printVariantWithPayload VariantsWithPayload.re:19:4 path:+VariantsWithPayload
+  addValueDeclaration +testManyPayloads VariantsWithPayload.re:38:4 path:+VariantsWithPayload
+  addValueDeclaration +printManyPayloads VariantsWithPayload.re:41:4 path:+VariantsWithPayload
   addTypeDeclaration A VariantsWithPayload.re:51:4 path:+VariantsWithPayload.simpleVariant
   addTypeDeclaration B VariantsWithPayload.re:52:4 path:+VariantsWithPayload.simpleVariant
   addTypeDeclaration C VariantsWithPayload.re:53:4 path:+VariantsWithPayload.simpleVariant
-  addValueDeclaration testSimpleVariant VariantsWithPayload.re:56:4 path:+VariantsWithPayload
+  addValueDeclaration +testSimpleVariant VariantsWithPayload.re:56:4 path:+VariantsWithPayload
   addTypeDeclaration A VariantsWithPayload.re:60:4 path:+VariantsWithPayload.variantWithPayloads
   addTypeDeclaration B VariantsWithPayload.re:61:4 path:+VariantsWithPayload.variantWithPayloads
   addTypeDeclaration C VariantsWithPayload.re:62:4 path:+VariantsWithPayload.variantWithPayloads
   addTypeDeclaration D VariantsWithPayload.re:63:4 path:+VariantsWithPayload.variantWithPayloads
   addTypeDeclaration E VariantsWithPayload.re:64:4 path:+VariantsWithPayload.variantWithPayloads
-  addValueDeclaration testVariantWithPayloads VariantsWithPayload.re:67:4 path:+VariantsWithPayload
-  addValueDeclaration printVariantWithPayloads VariantsWithPayload.re:70:4 path:+VariantsWithPayload
+  addValueDeclaration +testVariantWithPayloads VariantsWithPayload.re:67:4 path:+VariantsWithPayload
+  addValueDeclaration +printVariantWithPayloads VariantsWithPayload.re:70:4 path:+VariantsWithPayload
   addTypeDeclaration R VariantsWithPayload.re:100:4 path:+VariantsWithPayload.variant1Int
-  addValueDeclaration testVariant1Int VariantsWithPayload.re:103:4 path:+VariantsWithPayload
+  addValueDeclaration +testVariant1Int VariantsWithPayload.re:103:4 path:+VariantsWithPayload
   addTypeDeclaration R VariantsWithPayload.re:107:4 path:+VariantsWithPayload.variant1Object
-  addValueDeclaration testVariant1Object VariantsWithPayload.re:110:4 path:+VariantsWithPayload
+  addValueDeclaration +testVariant1Object VariantsWithPayload.re:110:4 path:+VariantsWithPayload
   addTypeDeclaration +x VariantsWithPayload.re:2:2 path:+VariantsWithPayload.+payload
   addTypeDeclaration +y VariantsWithPayload.re:3:2 path:+VariantsWithPayload.+payload
   addValueReference VariantsWithPayload.re:16:4 --> VariantsWithPayload.re:16:23
@@ -944,7 +944,7 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/FirstClassModulesInterface.cmt
   addTypeDeclaration x FirstClassModulesInterface.re:2:2 path:+FirstClassModulesInterface.record
   addTypeDeclaration y FirstClassModulesInterface.re:3:2 path:+FirstClassModulesInterface.record
-  addValueDeclaration r FirstClassModulesInterface.re:6:4 path:+FirstClassModulesInterface
+  addValueDeclaration +r FirstClassModulesInterface.re:6:4 path:+FirstClassModulesInterface
   addTypeDeclaration +x FirstClassModulesInterface.re:2:2 path:+FirstClassModulesInterface.+record
   addTypeDeclaration +y FirstClassModulesInterface.re:3:2 path:+FirstClassModulesInterface.+record
   addValueReference FirstClassModulesInterface.rei:7:0 --> FirstClassModulesInterface.re:6:4
@@ -953,10 +953,10 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Unboxed.cmt
   addTypeDeclaration A Unboxed.re:4:4 path:+Unboxed.v1
   addTypeDeclaration A Unboxed.re:9:4 path:+Unboxed.v2
-  addValueDeclaration testV1 Unboxed.re:12:4 path:+Unboxed
+  addValueDeclaration +testV1 Unboxed.re:12:4 path:+Unboxed
   addTypeDeclaration x Unboxed.re:16:11 path:+Unboxed.r1
   addTypeDeclaration B Unboxed.re:21:4 path:+Unboxed.r2
-  addValueDeclaration r2Test Unboxed.re:24:4 path:+Unboxed
+  addValueDeclaration +r2Test Unboxed.re:24:4 path:+Unboxed
   addTypeDeclaration +A Unboxed.re:4:4 path:+Unboxed.+v1
   addTypeDeclaration +A Unboxed.re:9:4 path:+Unboxed.+v2
   addValueReference Unboxed.re:12:4 --> Unboxed.re:12:14
@@ -966,31 +966,31 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTypeTest.cmti
   addTypeDeclaration A DeadTypeTest.rei:2:4 path:DeadTypeTest.t
   addTypeDeclaration B DeadTypeTest.rei:3:4 path:DeadTypeTest.t
-  addValueDeclaration a DeadTypeTest.rei:4:0 path:DeadTypeTest
+  addValueDeclaration +a DeadTypeTest.rei:4:0 path:DeadTypeTest
   addTypeDeclaration OnlyInImplementation DeadTypeTest.rei:7:4 path:DeadTypeTest.deadType
   addTypeDeclaration OnlyInInterface DeadTypeTest.rei:8:4 path:DeadTypeTest.deadType
   addTypeDeclaration InBoth DeadTypeTest.rei:9:4 path:DeadTypeTest.deadType
   addTypeDeclaration InNeither DeadTypeTest.rei:10:4 path:DeadTypeTest.deadType
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportJsValue.cmt
-  addValueDeclaration round ImportJsValue.re:1:0 path:+ImportJsValue
+  addValueDeclaration +round ImportJsValue.re:1:0 path:+ImportJsValue
   addTypeDeclaration x ImportJsValue.re:10:2 path:+ImportJsValue.point
   addTypeDeclaration y ImportJsValue.re:11:2 path:+ImportJsValue.point
-  addValueDeclaration area ImportJsValue.re:14:0 path:+ImportJsValue
-  addValueDeclaration returnMixedArray ImportJsValue.re:21:0 path:+ImportJsValue
-  addValueDeclaration roundedNumber ImportJsValue.re:25:4 path:+ImportJsValue
-  addValueDeclaration areaValue ImportJsValue.re:28:4 path:+ImportJsValue
-  addValueDeclaration getProp ImportJsValue.re:35:2 path:+ImportJsValue.AbsoluteValue
-  addValueDeclaration getAbs ImportJsValue.re:38:6 path:+ImportJsValue.AbsoluteValue
-  addValueDeclaration useGetProp ImportJsValue.re:45:4 path:+ImportJsValue
-  addValueDeclaration useGetAbs ImportJsValue.re:48:4 path:+ImportJsValue
-  addValueDeclaration useColor ImportJsValue.re:56:0 path:+ImportJsValue
-  addValueDeclaration higherOrder ImportJsValue.re:58:0 path:+ImportJsValue
-  addValueDeclaration returnedFromHigherOrder ImportJsValue.re:62:4 path:+ImportJsValue
+  addValueDeclaration +area ImportJsValue.re:14:0 path:+ImportJsValue
+  addValueDeclaration +returnMixedArray ImportJsValue.re:21:0 path:+ImportJsValue
+  addValueDeclaration +roundedNumber ImportJsValue.re:25:4 path:+ImportJsValue
+  addValueDeclaration +areaValue ImportJsValue.re:28:4 path:+ImportJsValue
+  addValueDeclaration +getProp ImportJsValue.re:35:2 path:+ImportJsValue.AbsoluteValue
+  addValueDeclaration +getAbs ImportJsValue.re:38:6 path:+ImportJsValue.AbsoluteValue
+  addValueDeclaration +useGetProp ImportJsValue.re:45:4 path:+ImportJsValue
+  addValueDeclaration +useGetAbs ImportJsValue.re:48:4 path:+ImportJsValue
+  addValueDeclaration +useColor ImportJsValue.re:56:0 path:+ImportJsValue
+  addValueDeclaration +higherOrder ImportJsValue.re:58:0 path:+ImportJsValue
+  addValueDeclaration +returnedFromHigherOrder ImportJsValue.re:62:4 path:+ImportJsValue
   addTypeDeclaration I ImportJsValue.re:65:4 path:+ImportJsValue.variant
   addTypeDeclaration S ImportJsValue.re:66:4 path:+ImportJsValue.variant
-  addValueDeclaration convertVariant ImportJsValue.re:68:0 path:+ImportJsValue
-  addValueDeclaration polymorphic ImportJsValue.re:71:0 path:+ImportJsValue
-  addValueDeclaration default ImportJsValue.re:73:0 path:+ImportJsValue
+  addValueDeclaration +convertVariant ImportJsValue.re:68:0 path:+ImportJsValue
+  addValueDeclaration +polymorphic ImportJsValue.re:71:0 path:+ImportJsValue
+  addValueDeclaration +default ImportJsValue.re:73:0 path:+ImportJsValue
   addTypeDeclaration +x ImportJsValue.re:10:2 path:+ImportJsValue.+point
   addTypeDeclaration +y ImportJsValue.re:11:2 path:+ImportJsValue.+point
   addValueReference ImportJsValue.re:25:4 --> ImportJsValue.re:1:0
@@ -1006,18 +1006,18 @@
   addTypeDeclaration +I ImportJsValue.re:65:4 path:+ImportJsValue.+variant
   addTypeDeclaration +S ImportJsValue.re:66:4 path:+ImportJsValue.+variant
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/References.cmt
-  addValueDeclaration create References.re:4:4 path:+References
-  addValueDeclaration access References.re:7:4 path:+References
-  addValueDeclaration update References.re:10:4 path:+References
-  addValueDeclaration get References.re:17:2 path:+References.R
-  addValueDeclaration make References.re:18:2 path:+References.R
-  addValueDeclaration set References.re:19:2 path:+References.R
-  addValueDeclaration get References.re:31:4 path:+References
-  addValueDeclaration make References.re:34:4 path:+References
-  addValueDeclaration set References.re:37:4 path:+References
+  addValueDeclaration +create References.re:4:4 path:+References
+  addValueDeclaration +access References.re:7:4 path:+References
+  addValueDeclaration +update References.re:10:4 path:+References
+  addValueDeclaration +get References.re:17:2 path:+References.R
+  addValueDeclaration +make References.re:18:2 path:+References.R
+  addValueDeclaration +set References.re:19:2 path:+References.R
+  addValueDeclaration +get References.re:31:4 path:+References
+  addValueDeclaration +make References.re:34:4 path:+References
+  addValueDeclaration +set References.re:37:4 path:+References
   addTypeDeclaration x References.re:39:27 path:+References.requiresConversion
-  addValueDeclaration destroysRefIdentity References.re:43:4 path:+References
-  addValueDeclaration preserveRefIdentity References.re:47:4 path:+References
+  addValueDeclaration +destroysRefIdentity References.re:43:4 path:+References
+  addValueDeclaration +preserveRefIdentity References.re:47:4 path:+References
   addValueReference References.re:4:4 --> References.re:4:14
   addValueReference References.re:7:4 --> References.re:7:13
   addValueReference References.re:10:4 --> References.re:10:13
@@ -1038,25 +1038,25 @@
   addValueReference References.re:18:2 --> References.re:23:6
   addValueReference References.re:19:2 --> References.re:24:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTestWithInterface.cmt
-  addValueDeclaration x DeadTestWithInterface.re:1:20 path:+DeadTestWithInterface.Ext_buffer
+  addValueDeclaration +x DeadTestWithInterface.re:1:20 path:+DeadTestWithInterface.Ext_buffer
   addValueDeclaration +x DeadTestWithInterface.re:2:6 path:+DeadTestWithInterface.Ext_buffer
   addValueReference DeadTestWithInterface.re:1:20 --> DeadTestWithInterface.re:2:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/JSResource.cmt
-  addValueDeclaration jSResource JSResource.re:3:0 path:+JSResource
+  addValueDeclaration +jSResource JSResource.re:3:0 path:+JSResource
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTestBlacklist.cmt
-  addValueDeclaration x DeadTestBlacklist.re:1:4 path:+DeadTestBlacklist
+  addValueDeclaration +x DeadTestBlacklist.re:1:4 path:+DeadTestBlacklist
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/NestedModulesInSignature.cmti
-  addValueDeclaration theAnswer NestedModulesInSignature.rei:2:2 path:NestedModulesInSignature.Universe
+  addValueDeclaration +theAnswer NestedModulesInSignature.rei:2:2 path:NestedModulesInSignature.Universe
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/CreateErrorHandler2.cmt
-  addValueDeclaration notification CreateErrorHandler2.re:3:6 path:+CreateErrorHandler2.Error2
+  addValueDeclaration +notification CreateErrorHandler2.re:3:6 path:+CreateErrorHandler2.Error2
   addValueReference CreateErrorHandler2.re:3:6 --> CreateErrorHandler2.re:3:21
   addValueReference ErrorHandler.rei:3:2 --> CreateErrorHandler2.re:3:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/BootloaderResource.cmt
-  addValueDeclaration read BootloaderResource.re:3:0 path:+BootloaderResource
+  addValueDeclaration +read BootloaderResource.re:3:0 path:+BootloaderResource
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTypeTest.cmt
   addTypeDeclaration A DeadTypeTest.re:2:4 path:+DeadTypeTest.t
   addTypeDeclaration B DeadTypeTest.re:3:4 path:+DeadTypeTest.t
-  addValueDeclaration a DeadTypeTest.re:4:4 path:+DeadTypeTest
+  addValueDeclaration +a DeadTypeTest.re:4:4 path:+DeadTypeTest
   addTypeDeclaration OnlyInImplementation DeadTypeTest.re:7:4 path:+DeadTypeTest.deadType
   addTypeDeclaration OnlyInInterface DeadTypeTest.re:8:4 path:+DeadTypeTest.deadType
   addTypeDeclaration InBoth DeadTypeTest.re:9:4 path:+DeadTypeTest.deadType
@@ -1068,27 +1068,27 @@
   addTypeDeclaration +OnlyInInterface DeadTypeTest.re:8:4 path:+DeadTypeTest.+deadType
   addTypeDeclaration +InBoth DeadTypeTest.re:9:4 path:+DeadTypeTest.+deadType
   addTypeDeclaration +InNeither DeadTypeTest.re:10:4 path:+DeadTypeTest.+deadType
-  addValueDeclaration _ DeadTypeTest.re:12:0 path:+DeadTypeTest
+  addValueDeclaration +_ DeadTypeTest.re:12:0 path:+DeadTypeTest
   addTypeReference DeadTypeTest.re:12:8 --> DeadTypeTest.re:7:4
-  addValueDeclaration _ DeadTypeTest.re:13:0 path:+DeadTypeTest
+  addValueDeclaration +_ DeadTypeTest.re:13:0 path:+DeadTypeTest
   addTypeReference DeadTypeTest.re:13:8 --> DeadTypeTest.re:9:4
   addValueReference DeadTypeTest.rei:4:0 --> DeadTypeTest.re:4:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/CreateErrorHandler1.cmt
-  addValueDeclaration notification CreateErrorHandler1.re:3:6 path:+CreateErrorHandler1.Error1
+  addValueDeclaration +notification CreateErrorHandler1.re:3:6 path:+CreateErrorHandler1.Error1
   addValueReference CreateErrorHandler1.re:3:6 --> CreateErrorHandler1.re:3:21
   addValueReference CreateErrorHandler1.re:3:6 --> CreateErrorHandler1.re:3:21
   addValueReference CreateErrorHandler1.re:8:0 --> ErrorHandler.rei:5:32
   addValueReference ErrorHandler.rei:3:2 --> CreateErrorHandler1.re:3:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/LetPrivate.cmt
-  addValueDeclaration y LetPrivate.re:5:4 path:+LetPrivate
+  addValueDeclaration +y LetPrivate.re:5:4 path:+LetPrivate
   addValueDeclaration +x LetPrivate.re:2:12 path:+LetPrivate.local_1
   addValueReference LetPrivate.re:5:4 --> LetPrivate.re:2:12
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ModuleAliases.cmt
   addTypeDeclaration inner ModuleAliases.re:3:19 path:+ModuleAliases.Outer.Inner.innerT
   addTypeDeclaration nested ModuleAliases.re:11:16 path:+ModuleAliases.Outer2.Inner2.InnerNested.t
-  addValueDeclaration testNested ModuleAliases.re:22:4 path:+ModuleAliases
-  addValueDeclaration testInner ModuleAliases.re:25:4 path:+ModuleAliases
-  addValueDeclaration testInner2 ModuleAliases.re:28:4 path:+ModuleAliases
+  addValueDeclaration +testNested ModuleAliases.re:22:4 path:+ModuleAliases
+  addValueDeclaration +testInner ModuleAliases.re:25:4 path:+ModuleAliases
+  addValueDeclaration +testInner2 ModuleAliases.re:28:4 path:+ModuleAliases
   addTypeDeclaration +inner ModuleAliases.re:3:19 path:+ModuleAliases.Outer.Inner.+innerT
   addTypeDeclaration +nested ModuleAliases.re:11:16 path:+ModuleAliases.Outer2.Inner2.InnerNested.+t
   addValueReference ModuleAliases.re:22:4 --> ModuleAliases.re:22:18
@@ -1096,103 +1096,103 @@
   addValueReference ModuleAliases.re:28:4 --> ModuleAliases.re:28:18
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadCodeInterface.cmt
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ExportWithRename.cmt
-  addValueDeclaration make ExportWithRename.re:3:4 path:+ExportWithRename
+  addValueDeclaration +make ExportWithRename.re:3:4 path:+ExportWithRename
   addValueReference ExportWithRename.re:3:4 --> ExportWithRename.re:3:13
   addValueReference ExportWithRename.re:3:4 --> React.re:5:0
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImmutableArray.cmti
-  addValueDeclaration get ImmutableArray.rei:5:15 path:ImmutableArray.Array
-  addValueDeclaration fromArray ImmutableArray.rei:7:0 path:ImmutableArray
-  addValueDeclaration toArray ImmutableArray.rei:10:0 path:ImmutableArray
-  addValueDeclaration length ImmutableArray.rei:12:0 path:ImmutableArray
-  addValueDeclaration size ImmutableArray.rei:16:0 path:ImmutableArray
-  addValueDeclaration get ImmutableArray.rei:18:0 path:ImmutableArray
-  addValueDeclaration getExn ImmutableArray.rei:20:0 path:ImmutableArray
-  addValueDeclaration getUnsafe ImmutableArray.rei:22:0 path:ImmutableArray
-  addValueDeclaration getUndefined ImmutableArray.rei:24:0 path:ImmutableArray
-  addValueDeclaration shuffle ImmutableArray.rei:26:0 path:ImmutableArray
-  addValueDeclaration reverse ImmutableArray.rei:28:0 path:ImmutableArray
-  addValueDeclaration makeUninitialized ImmutableArray.rei:30:0 path:ImmutableArray
-  addValueDeclaration makeUninitializedUnsafe ImmutableArray.rei:32:0 path:ImmutableArray
-  addValueDeclaration make ImmutableArray.rei:34:0 path:ImmutableArray
-  addValueDeclaration range ImmutableArray.rei:36:0 path:ImmutableArray
-  addValueDeclaration rangeBy ImmutableArray.rei:38:0 path:ImmutableArray
-  addValueDeclaration makeByU ImmutableArray.rei:40:0 path:ImmutableArray
-  addValueDeclaration makeBy ImmutableArray.rei:41:0 path:ImmutableArray
-  addValueDeclaration makeByAndShuffleU ImmutableArray.rei:43:0 path:ImmutableArray
-  addValueDeclaration makeByAndShuffle ImmutableArray.rei:44:0 path:ImmutableArray
-  addValueDeclaration zip ImmutableArray.rei:46:0 path:ImmutableArray
-  addValueDeclaration zipByU ImmutableArray.rei:48:0 path:ImmutableArray
-  addValueDeclaration zipBy ImmutableArray.rei:49:0 path:ImmutableArray
-  addValueDeclaration unzip ImmutableArray.rei:51:0 path:ImmutableArray
-  addValueDeclaration concat ImmutableArray.rei:53:0 path:ImmutableArray
-  addValueDeclaration concatMany ImmutableArray.rei:55:0 path:ImmutableArray
-  addValueDeclaration slice ImmutableArray.rei:57:0 path:ImmutableArray
-  addValueDeclaration sliceToEnd ImmutableArray.rei:59:0 path:ImmutableArray
-  addValueDeclaration copy ImmutableArray.rei:61:0 path:ImmutableArray
-  addValueDeclaration forEachU ImmutableArray.rei:63:0 path:ImmutableArray
-  addValueDeclaration forEach ImmutableArray.rei:64:0 path:ImmutableArray
-  addValueDeclaration mapU ImmutableArray.rei:66:0 path:ImmutableArray
-  addValueDeclaration map ImmutableArray.rei:67:0 path:ImmutableArray
-  addValueDeclaration keepWithIndexU ImmutableArray.rei:69:0 path:ImmutableArray
-  addValueDeclaration keepWithIndex ImmutableArray.rei:70:0 path:ImmutableArray
-  addValueDeclaration keepMapU ImmutableArray.rei:72:0 path:ImmutableArray
-  addValueDeclaration keepMap ImmutableArray.rei:73:0 path:ImmutableArray
-  addValueDeclaration forEachWithIndexU ImmutableArray.rei:75:0 path:ImmutableArray
-  addValueDeclaration forEachWithIndex ImmutableArray.rei:76:0 path:ImmutableArray
-  addValueDeclaration mapWithIndexU ImmutableArray.rei:78:0 path:ImmutableArray
-  addValueDeclaration mapWithIndex ImmutableArray.rei:79:0 path:ImmutableArray
-  addValueDeclaration partitionU ImmutableArray.rei:81:0 path:ImmutableArray
-  addValueDeclaration partition ImmutableArray.rei:82:0 path:ImmutableArray
-  addValueDeclaration reduceU ImmutableArray.rei:84:0 path:ImmutableArray
-  addValueDeclaration reduce ImmutableArray.rei:85:0 path:ImmutableArray
-  addValueDeclaration reduceReverseU ImmutableArray.rei:87:0 path:ImmutableArray
-  addValueDeclaration reduceReverse ImmutableArray.rei:88:0 path:ImmutableArray
-  addValueDeclaration reduceReverse2U ImmutableArray.rei:90:0 path:ImmutableArray
-  addValueDeclaration reduceReverse2 ImmutableArray.rei:91:0 path:ImmutableArray
-  addValueDeclaration someU ImmutableArray.rei:93:0 path:ImmutableArray
-  addValueDeclaration some ImmutableArray.rei:94:0 path:ImmutableArray
-  addValueDeclaration everyU ImmutableArray.rei:96:0 path:ImmutableArray
-  addValueDeclaration every ImmutableArray.rei:97:0 path:ImmutableArray
-  addValueDeclaration every2U ImmutableArray.rei:99:0 path:ImmutableArray
-  addValueDeclaration every2 ImmutableArray.rei:100:0 path:ImmutableArray
-  addValueDeclaration some2U ImmutableArray.rei:102:0 path:ImmutableArray
-  addValueDeclaration some2 ImmutableArray.rei:103:0 path:ImmutableArray
-  addValueDeclaration cmpU ImmutableArray.rei:105:0 path:ImmutableArray
-  addValueDeclaration cmp ImmutableArray.rei:106:0 path:ImmutableArray
-  addValueDeclaration eqU ImmutableArray.rei:108:0 path:ImmutableArray
-  addValueDeclaration eq ImmutableArray.rei:109:0 path:ImmutableArray
+  addValueDeclaration +get ImmutableArray.rei:5:15 path:ImmutableArray.Array
+  addValueDeclaration +fromArray ImmutableArray.rei:7:0 path:ImmutableArray
+  addValueDeclaration +toArray ImmutableArray.rei:10:0 path:ImmutableArray
+  addValueDeclaration +length ImmutableArray.rei:12:0 path:ImmutableArray
+  addValueDeclaration +size ImmutableArray.rei:16:0 path:ImmutableArray
+  addValueDeclaration +get ImmutableArray.rei:18:0 path:ImmutableArray
+  addValueDeclaration +getExn ImmutableArray.rei:20:0 path:ImmutableArray
+  addValueDeclaration +getUnsafe ImmutableArray.rei:22:0 path:ImmutableArray
+  addValueDeclaration +getUndefined ImmutableArray.rei:24:0 path:ImmutableArray
+  addValueDeclaration +shuffle ImmutableArray.rei:26:0 path:ImmutableArray
+  addValueDeclaration +reverse ImmutableArray.rei:28:0 path:ImmutableArray
+  addValueDeclaration +makeUninitialized ImmutableArray.rei:30:0 path:ImmutableArray
+  addValueDeclaration +makeUninitializedUnsafe ImmutableArray.rei:32:0 path:ImmutableArray
+  addValueDeclaration +make ImmutableArray.rei:34:0 path:ImmutableArray
+  addValueDeclaration +range ImmutableArray.rei:36:0 path:ImmutableArray
+  addValueDeclaration +rangeBy ImmutableArray.rei:38:0 path:ImmutableArray
+  addValueDeclaration +makeByU ImmutableArray.rei:40:0 path:ImmutableArray
+  addValueDeclaration +makeBy ImmutableArray.rei:41:0 path:ImmutableArray
+  addValueDeclaration +makeByAndShuffleU ImmutableArray.rei:43:0 path:ImmutableArray
+  addValueDeclaration +makeByAndShuffle ImmutableArray.rei:44:0 path:ImmutableArray
+  addValueDeclaration +zip ImmutableArray.rei:46:0 path:ImmutableArray
+  addValueDeclaration +zipByU ImmutableArray.rei:48:0 path:ImmutableArray
+  addValueDeclaration +zipBy ImmutableArray.rei:49:0 path:ImmutableArray
+  addValueDeclaration +unzip ImmutableArray.rei:51:0 path:ImmutableArray
+  addValueDeclaration +concat ImmutableArray.rei:53:0 path:ImmutableArray
+  addValueDeclaration +concatMany ImmutableArray.rei:55:0 path:ImmutableArray
+  addValueDeclaration +slice ImmutableArray.rei:57:0 path:ImmutableArray
+  addValueDeclaration +sliceToEnd ImmutableArray.rei:59:0 path:ImmutableArray
+  addValueDeclaration +copy ImmutableArray.rei:61:0 path:ImmutableArray
+  addValueDeclaration +forEachU ImmutableArray.rei:63:0 path:ImmutableArray
+  addValueDeclaration +forEach ImmutableArray.rei:64:0 path:ImmutableArray
+  addValueDeclaration +mapU ImmutableArray.rei:66:0 path:ImmutableArray
+  addValueDeclaration +map ImmutableArray.rei:67:0 path:ImmutableArray
+  addValueDeclaration +keepWithIndexU ImmutableArray.rei:69:0 path:ImmutableArray
+  addValueDeclaration +keepWithIndex ImmutableArray.rei:70:0 path:ImmutableArray
+  addValueDeclaration +keepMapU ImmutableArray.rei:72:0 path:ImmutableArray
+  addValueDeclaration +keepMap ImmutableArray.rei:73:0 path:ImmutableArray
+  addValueDeclaration +forEachWithIndexU ImmutableArray.rei:75:0 path:ImmutableArray
+  addValueDeclaration +forEachWithIndex ImmutableArray.rei:76:0 path:ImmutableArray
+  addValueDeclaration +mapWithIndexU ImmutableArray.rei:78:0 path:ImmutableArray
+  addValueDeclaration +mapWithIndex ImmutableArray.rei:79:0 path:ImmutableArray
+  addValueDeclaration +partitionU ImmutableArray.rei:81:0 path:ImmutableArray
+  addValueDeclaration +partition ImmutableArray.rei:82:0 path:ImmutableArray
+  addValueDeclaration +reduceU ImmutableArray.rei:84:0 path:ImmutableArray
+  addValueDeclaration +reduce ImmutableArray.rei:85:0 path:ImmutableArray
+  addValueDeclaration +reduceReverseU ImmutableArray.rei:87:0 path:ImmutableArray
+  addValueDeclaration +reduceReverse ImmutableArray.rei:88:0 path:ImmutableArray
+  addValueDeclaration +reduceReverse2U ImmutableArray.rei:90:0 path:ImmutableArray
+  addValueDeclaration +reduceReverse2 ImmutableArray.rei:91:0 path:ImmutableArray
+  addValueDeclaration +someU ImmutableArray.rei:93:0 path:ImmutableArray
+  addValueDeclaration +some ImmutableArray.rei:94:0 path:ImmutableArray
+  addValueDeclaration +everyU ImmutableArray.rei:96:0 path:ImmutableArray
+  addValueDeclaration +every ImmutableArray.rei:97:0 path:ImmutableArray
+  addValueDeclaration +every2U ImmutableArray.rei:99:0 path:ImmutableArray
+  addValueDeclaration +every2 ImmutableArray.rei:100:0 path:ImmutableArray
+  addValueDeclaration +some2U ImmutableArray.rei:102:0 path:ImmutableArray
+  addValueDeclaration +some2 ImmutableArray.rei:103:0 path:ImmutableArray
+  addValueDeclaration +cmpU ImmutableArray.rei:105:0 path:ImmutableArray
+  addValueDeclaration +cmp ImmutableArray.rei:106:0 path:ImmutableArray
+  addValueDeclaration +eqU ImmutableArray.rei:108:0 path:ImmutableArray
+  addValueDeclaration +eq ImmutableArray.rei:109:0 path:ImmutableArray
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportHookDefault.cmt
   addTypeDeclaration name ImportHookDefault.re:2:2 path:+ImportHookDefault.person
   addTypeDeclaration age ImportHookDefault.re:3:2 path:+ImportHookDefault.person
-  addValueDeclaration makeProps ImportHookDefault.re:6:0 path:+ImportHookDefault
-  addValueDeclaration make ImportHookDefault.re:6:0 path:+ImportHookDefault
-  addValueDeclaration make2Props ImportHookDefault.re:16:0 path:+ImportHookDefault
-  addValueDeclaration make2 ImportHookDefault.re:16:0 path:+ImportHookDefault
+  addValueDeclaration +makeProps ImportHookDefault.re:6:0 path:+ImportHookDefault
+  addValueDeclaration +make ImportHookDefault.re:6:0 path:+ImportHookDefault
+  addValueDeclaration +make2Props ImportHookDefault.re:16:0 path:+ImportHookDefault
+  addValueDeclaration +make2 ImportHookDefault.re:16:0 path:+ImportHookDefault
   addTypeDeclaration +name ImportHookDefault.re:2:2 path:+ImportHookDefault.+person
   addTypeDeclaration +age ImportHookDefault.re:3:2 path:+ImportHookDefault.+person
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/UseImportJsValue.cmt
-  addValueDeclaration useGetProp UseImportJsValue.re:2:4 path:+UseImportJsValue
-  addValueDeclaration useTypeImportedInOtherModule UseImportJsValue.re:6:4 path:+UseImportJsValue
+  addValueDeclaration +useGetProp UseImportJsValue.re:2:4 path:+UseImportJsValue
+  addValueDeclaration +useTypeImportedInOtherModule UseImportJsValue.re:6:4 path:+UseImportJsValue
   addValueReference UseImportJsValue.re:2:4 --> UseImportJsValue.re:2:18
   addValueReference UseImportJsValue.re:2:4 --> ImportJsValue.re:35:2
   addValueReference UseImportJsValue.re:6:4 --> UseImportJsValue.re:6:36
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TestImport.cmt
-  addValueDeclaration innerStuffContents TestImport.re:1:0 path:+TestImport
-  addValueDeclaration innerStuffContentsAsEmptyObject TestImport.re:9:0 path:+TestImport
-  addValueDeclaration innerStuffContents TestImport.re:18:4 path:+TestImport
-  addValueDeclaration valueStartingWithUpperCaseLetter TestImport.re:20:0 path:+TestImport
-  addValueDeclaration defaultValue TestImport.re:24:0 path:+TestImport
+  addValueDeclaration +innerStuffContents TestImport.re:1:0 path:+TestImport
+  addValueDeclaration +innerStuffContentsAsEmptyObject TestImport.re:9:0 path:+TestImport
+  addValueDeclaration +innerStuffContents TestImport.re:18:4 path:+TestImport
+  addValueDeclaration +valueStartingWithUpperCaseLetter TestImport.re:20:0 path:+TestImport
+  addValueDeclaration +defaultValue TestImport.re:24:0 path:+TestImport
   addTypeDeclaration text TestImport.re:28:16 path:+TestImport.message
-  addValueDeclaration make TestImport.re:30:0 path:+TestImport
-  addValueDeclaration make TestImport.re:42:4 path:+TestImport
-  addValueDeclaration defaultValue2 TestImport.re:44:0 path:+TestImport
+  addValueDeclaration +make TestImport.re:30:0 path:+TestImport
+  addValueDeclaration +make TestImport.re:42:4 path:+TestImport
+  addValueDeclaration +defaultValue2 TestImport.re:44:0 path:+TestImport
   addValueReference TestImport.re:18:4 --> TestImport.re:1:0
   addTypeDeclaration +text TestImport.re:28:16 path:+TestImport.+message
   addValueReference TestImport.re:42:4 --> TestImport.re:30:0
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TestImmutableArray.cmt
-  addValueDeclaration testImmutableArrayGet TestImmutableArray.re:2:4 path:+TestImmutableArray
-  addValueDeclaration testBeltArrayGet TestImmutableArray.re:9:4 path:+TestImmutableArray
-  addValueDeclaration testBeltArraySet TestImmutableArray.re:11:4 path:+TestImmutableArray
+  addValueDeclaration +testImmutableArrayGet TestImmutableArray.re:2:4 path:+TestImmutableArray
+  addValueDeclaration +testBeltArrayGet TestImmutableArray.re:9:4 path:+TestImmutableArray
+  addValueDeclaration +testBeltArraySet TestImmutableArray.re:11:4 path:+TestImmutableArray
   addValueReference TestImmutableArray.re:2:4 --> TestImmutableArray.re:2:28
   addValueReference TestImmutableArray.re:2:4 --> ImmutableArray.rei:5:15
   addValueReference TestImmutableArray.re:9:4 --> TestImmutableArray.re:9:23
@@ -1200,19 +1200,19 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportHooks.cmt
   addTypeDeclaration name ImportHooks.re:3:2 path:+ImportHooks.person
   addTypeDeclaration age ImportHooks.re:4:2 path:+ImportHooks.person
-  addValueDeclaration makeProps ImportHooks.re:15:0 path:+ImportHooks
-  addValueDeclaration make ImportHooks.re:15:0 path:+ImportHooks
-  addValueDeclaration foo ImportHooks.re:21:0 path:+ImportHooks
+  addValueDeclaration +makeProps ImportHooks.re:15:0 path:+ImportHooks
+  addValueDeclaration +make ImportHooks.re:15:0 path:+ImportHooks
+  addValueDeclaration +foo ImportHooks.re:21:0 path:+ImportHooks
   addTypeDeclaration +name ImportHooks.re:3:2 path:+ImportHooks.+person
   addTypeDeclaration +age ImportHooks.re:4:2 path:+ImportHooks.+person
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTestWithInterface.cmti
   Interface 0
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/RequireCond.cmt
-  addValueDeclaration make RequireCond.re:1:0 path:+RequireCond
-  addValueDeclaration either RequireCond.re:14:0 path:+RequireCond
+  addValueDeclaration +make RequireCond.re:1:0 path:+RequireCond
+  addValueDeclaration +either RequireCond.re:14:0 path:+RequireCond
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/BucklescriptAnnotations.cmt
-  addValueDeclaration foo BucklescriptAnnotations.re:19:4 path:+BucklescriptAnnotations
-  addValueDeclaration bar BucklescriptAnnotations.re:21:4 path:+BucklescriptAnnotations
+  addValueDeclaration +foo BucklescriptAnnotations.re:19:4 path:+BucklescriptAnnotations
+  addValueDeclaration +bar BucklescriptAnnotations.re:21:4 path:+BucklescriptAnnotations
   addValueReference BucklescriptAnnotations.re:19:4 --> BucklescriptAnnotations.re:19:11
   addValueDeclaration +f BucklescriptAnnotations.re:22:6 path:+BucklescriptAnnotations
   addValueReference BucklescriptAnnotations.re:22:6 --> BucklescriptAnnotations.re:21:11
@@ -1221,8 +1221,8 @@
   addTypeDeclaration Root DeadRT.rei:2:4 path:DeadRT.moduleAccessPath
   addTypeDeclaration Kaboom DeadRT.rei:3:4 path:DeadRT.moduleAccessPath
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ComponentAsProp.cmt
-  addValueDeclaration component ComponentAsProp.re:1:4 path:+ComponentAsProp
-  addValueDeclaration make ComponentAsProp.re:5:4 path:+ComponentAsProp
+  addValueDeclaration +component ComponentAsProp.re:1:4 path:+ComponentAsProp
+  addValueDeclaration +make ComponentAsProp.re:5:4 path:+ComponentAsProp
   addValueReference ComponentAsProp.re:1:4 --> ReasonReact.rei:153:0
   addValueReference ComponentAsProp.re:5:4 --> ComponentAsProp.re:5:13
   addValueReference ComponentAsProp.re:5:4 --> ComponentAsProp.re:5:21
@@ -1236,43 +1236,43 @@
   addTypeDeclaration x Records.re:5:2 path:+Records.coord
   addTypeDeclaration y Records.re:6:2 path:+Records.coord
   addTypeDeclaration z Records.re:7:2 path:+Records.coord
-  addValueDeclaration origin Records.re:11:4 path:+Records
-  addValueDeclaration computeArea Records.re:14:4 path:+Records
-  addValueDeclaration coord2d Records.re:18:4 path:+Records
+  addValueDeclaration +origin Records.re:11:4 path:+Records
+  addValueDeclaration +computeArea Records.re:14:4 path:+Records
+  addValueDeclaration +coord2d Records.re:18:4 path:+Records
   addTypeDeclaration name Records.re:22:2 path:+Records.person
   addTypeDeclaration age Records.re:23:2 path:+Records.person
   addTypeDeclaration address Records.re:24:2 path:+Records.person
   addTypeDeclaration name Records.re:29:2 path:+Records.business
   addTypeDeclaration owner Records.re:30:2 path:+Records.business
   addTypeDeclaration address Records.re:31:2 path:+Records.business
-  addValueDeclaration getOpt Records.re:34:4 path:+Records
-  addValueDeclaration findAddress Records.re:37:4 path:+Records
-  addValueDeclaration someBusiness Records.re:41:4 path:+Records
-  addValueDeclaration findAllAddresses Records.re:44:4 path:+Records
+  addValueDeclaration +getOpt Records.re:34:4 path:+Records
+  addValueDeclaration +findAddress Records.re:37:4 path:+Records
+  addValueDeclaration +someBusiness Records.re:41:4 path:+Records
+  addValueDeclaration +findAllAddresses Records.re:44:4 path:+Records
   addTypeDeclaration num Records.re:56:2 path:+Records.payload
   addTypeDeclaration payload Records.re:57:2 path:+Records.payload
-  addValueDeclaration getPayload Records.re:61:4 path:+Records
+  addValueDeclaration +getPayload Records.re:61:4 path:+Records
   addTypeDeclaration v Records.re:65:2 path:+Records.record
   addTypeDeclaration w Records.re:66:2 path:+Records.record
-  addValueDeclaration getPayloadRecord Records.re:70:4 path:+Records
-  addValueDeclaration recordValue Records.re:73:4 path:+Records
-  addValueDeclaration payloadValue Records.re:76:4 path:+Records
-  addValueDeclaration getPayloadRecordPlusOne Records.re:79:4 path:+Records
+  addValueDeclaration +getPayloadRecord Records.re:70:4 path:+Records
+  addValueDeclaration +recordValue Records.re:73:4 path:+Records
+  addValueDeclaration +payloadValue Records.re:76:4 path:+Records
+  addValueDeclaration +getPayloadRecordPlusOne Records.re:79:4 path:+Records
   addTypeDeclaration name Records.re:86:2 path:+Records.business2
   addTypeDeclaration owner Records.re:87:2 path:+Records.business2
   addTypeDeclaration address2 Records.re:88:2 path:+Records.business2
-  addValueDeclaration findAddress2 Records.re:92:4 path:+Records
-  addValueDeclaration someBusiness2 Records.re:96:4 path:+Records
-  addValueDeclaration computeArea3 Records.re:103:4 path:+Records
-  addValueDeclaration computeArea4 Records.re:115:4 path:+Records
+  addValueDeclaration +findAddress2 Records.re:92:4 path:+Records
+  addValueDeclaration +someBusiness2 Records.re:96:4 path:+Records
+  addValueDeclaration +computeArea3 Records.re:103:4 path:+Records
+  addValueDeclaration +computeArea4 Records.re:115:4 path:+Records
   addTypeDeclaration type_ Records.re:141:2 path:+Records.myRec
-  addValueDeclaration testMyRec Records.re:149:4 path:+Records
-  addValueDeclaration testMyRec2 Records.re:152:4 path:+Records
-  addValueDeclaration testMyObj Records.re:155:4 path:+Records
-  addValueDeclaration testMyObj2 Records.re:158:4 path:+Records
+  addValueDeclaration +testMyRec Records.re:149:4 path:+Records
+  addValueDeclaration +testMyRec2 Records.re:152:4 path:+Records
+  addValueDeclaration +testMyObj Records.re:155:4 path:+Records
+  addValueDeclaration +testMyObj2 Records.re:158:4 path:+Records
   addTypeDeclaration type_ Records.re:162:2 path:+Records.myRecBsAs
-  addValueDeclaration testMyRecBsAs Records.re:167:4 path:+Records
-  addValueDeclaration testMyRecBsAs2 Records.re:170:4 path:+Records
+  addValueDeclaration +testMyRecBsAs Records.re:167:4 path:+Records
+  addValueDeclaration +testMyRecBsAs2 Records.re:170:4 path:+Records
   addTypeDeclaration +x Records.re:5:2 path:+Records.+coord
   addTypeDeclaration +y Records.re:6:2 path:+Records.+coord
   addTypeDeclaration +z Records.re:7:2 path:+Records.+coord
@@ -1351,29 +1351,29 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadRT.cmt
   addTypeDeclaration Root DeadRT.re:2:4 path:+DeadRT.moduleAccessPath
   addTypeDeclaration Kaboom DeadRT.re:3:4 path:+DeadRT.moduleAccessPath
-  addValueDeclaration emitModuleAccessPath DeadRT.re:5:8 path:+DeadRT
+  addValueDeclaration +emitModuleAccessPath DeadRT.re:5:8 path:+DeadRT
   addTypeDeclaration +Root DeadRT.re:2:4 path:+DeadRT.+moduleAccessPath
   addTypeDeclaration +Kaboom DeadRT.re:3:4 path:+DeadRT.+moduleAccessPath
   addValueReference DeadRT.re:5:8 --> DeadRT.re:7:9
   addValueReference DeadRT.re:5:8 --> DeadRT.re:5:31
   addTypeReference DeadRT.re:11:16 --> DeadRT.re:3:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportIndex.cmt
-  addValueDeclaration makeProps ImportIndex.re:2:0 path:+ImportIndex
-  addValueDeclaration make ImportIndex.re:2:0 path:+ImportIndex
+  addValueDeclaration +makeProps ImportIndex.re:2:0 path:+ImportIndex
+  addValueDeclaration +make ImportIndex.re:2:0 path:+ImportIndex
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Hooks.cmt
   addTypeDeclaration name Hooks.re:1:16 path:+Hooks.vehicle
-  addValueDeclaration make Hooks.re:4:4 path:+Hooks
-  addValueDeclaration default Hooks.re:36:4 path:+Hooks
-  addValueDeclaration anotherComponent Hooks.re:40:4 path:+Hooks
-  addValueDeclaration functionWithRenamedArgs Hooks.re:80:4 path:+Hooks
-  addValueDeclaration componentWithRenamedArgs Hooks.re:87:4 path:+Hooks
-  addValueDeclaration makeWithRef Hooks.re:94:4 path:+Hooks
-  addValueDeclaration testForwardRef Hooks.re:105:4 path:+Hooks
+  addValueDeclaration +make Hooks.re:4:4 path:+Hooks
+  addValueDeclaration +default Hooks.re:36:4 path:+Hooks
+  addValueDeclaration +anotherComponent Hooks.re:40:4 path:+Hooks
+  addValueDeclaration +functionWithRenamedArgs Hooks.re:80:4 path:+Hooks
+  addValueDeclaration +componentWithRenamedArgs Hooks.re:87:4 path:+Hooks
+  addValueDeclaration +makeWithRef Hooks.re:94:4 path:+Hooks
+  addValueDeclaration +testForwardRef Hooks.re:105:4 path:+Hooks
   addTypeDeclaration x Hooks.re:107:10 path:+Hooks.r
-  addValueDeclaration input Hooks.re:111:4 path:+Hooks
-  addValueDeclaration polymorphicComponent Hooks.re:130:4 path:+Hooks
-  addValueDeclaration functionReturningReactElement Hooks.re:134:4 path:+Hooks
-  addValueDeclaration aComponentWithChildren Hooks.re:156:4 path:+Hooks
+  addValueDeclaration +input Hooks.re:111:4 path:+Hooks
+  addValueDeclaration +polymorphicComponent Hooks.re:130:4 path:+Hooks
+  addValueDeclaration +functionReturningReactElement Hooks.re:134:4 path:+Hooks
+  addValueDeclaration +aComponentWithChildren Hooks.re:156:4 path:+Hooks
   addTypeDeclaration +name Hooks.re:1:16 path:+Hooks.+vehicle
   addValueReference Hooks.re:4:4 --> React.re:104:0
   addTypeReference Hooks.re:11:12 --> Hooks.re:1:16
@@ -1480,37 +1480,37 @@
   addTypeDeclaration x TestPromise.re:6:2 path:+TestPromise.fromPayload
   addTypeDeclaration s TestPromise.re:7:2 path:+TestPromise.fromPayload
   addTypeDeclaration result TestPromise.re:11:18 path:+TestPromise.toPayload
-  addValueDeclaration convert TestPromise.re:14:4 path:+TestPromise
+  addValueDeclaration +convert TestPromise.re:14:4 path:+TestPromise
   addTypeDeclaration +x TestPromise.re:6:2 path:+TestPromise.+fromPayload
   addTypeDeclaration +s TestPromise.re:7:2 path:+TestPromise.+fromPayload
   addTypeDeclaration +result TestPromise.re:11:18 path:+TestPromise.+toPayload
   addValueReference TestPromise.re:14:4 --> TestPromise.re:14:33
   addTypeReference TestPromise.re:14:32 --> TestPromise.re:7:2
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/NestedModulesInSignature.cmt
-  addValueDeclaration theAnswer NestedModulesInSignature.re:2:6 path:+NestedModulesInSignature.Universe
+  addValueDeclaration +theAnswer NestedModulesInSignature.re:2:6 path:+NestedModulesInSignature.Universe
   addValueReference NestedModulesInSignature.rei:2:2 --> NestedModulesInSignature.re:2:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Docstrings.cmt
-  addValueDeclaration flat Docstrings.re:3:4 path:+Docstrings
-  addValueDeclaration signMessage Docstrings.re:13:4 path:+Docstrings
-  addValueDeclaration one Docstrings.re:16:4 path:+Docstrings
-  addValueDeclaration two Docstrings.re:19:4 path:+Docstrings
-  addValueDeclaration tree Docstrings.re:22:4 path:+Docstrings
-  addValueDeclaration oneU Docstrings.re:25:4 path:+Docstrings
-  addValueDeclaration twoU Docstrings.re:28:4 path:+Docstrings
-  addValueDeclaration treeU Docstrings.re:31:4 path:+Docstrings
-  addValueDeclaration useParam Docstrings.re:34:4 path:+Docstrings
-  addValueDeclaration useParamU Docstrings.re:37:4 path:+Docstrings
-  addValueDeclaration unnamed1 Docstrings.re:40:4 path:+Docstrings
-  addValueDeclaration unnamed1U Docstrings.re:43:4 path:+Docstrings
-  addValueDeclaration unnamed2 Docstrings.re:46:4 path:+Docstrings
-  addValueDeclaration unnamed2U Docstrings.re:49:4 path:+Docstrings
-  addValueDeclaration grouped Docstrings.re:52:4 path:+Docstrings
-  addValueDeclaration unitArgWithoutConversion Docstrings.re:55:4 path:+Docstrings
-  addValueDeclaration unitArgWithoutConversionU Docstrings.re:58:4 path:+Docstrings
+  addValueDeclaration +flat Docstrings.re:3:4 path:+Docstrings
+  addValueDeclaration +signMessage Docstrings.re:13:4 path:+Docstrings
+  addValueDeclaration +one Docstrings.re:16:4 path:+Docstrings
+  addValueDeclaration +two Docstrings.re:19:4 path:+Docstrings
+  addValueDeclaration +tree Docstrings.re:22:4 path:+Docstrings
+  addValueDeclaration +oneU Docstrings.re:25:4 path:+Docstrings
+  addValueDeclaration +twoU Docstrings.re:28:4 path:+Docstrings
+  addValueDeclaration +treeU Docstrings.re:31:4 path:+Docstrings
+  addValueDeclaration +useParam Docstrings.re:34:4 path:+Docstrings
+  addValueDeclaration +useParamU Docstrings.re:37:4 path:+Docstrings
+  addValueDeclaration +unnamed1 Docstrings.re:40:4 path:+Docstrings
+  addValueDeclaration +unnamed1U Docstrings.re:43:4 path:+Docstrings
+  addValueDeclaration +unnamed2 Docstrings.re:46:4 path:+Docstrings
+  addValueDeclaration +unnamed2U Docstrings.re:49:4 path:+Docstrings
+  addValueDeclaration +grouped Docstrings.re:52:4 path:+Docstrings
+  addValueDeclaration +unitArgWithoutConversion Docstrings.re:55:4 path:+Docstrings
+  addValueDeclaration +unitArgWithoutConversionU Docstrings.re:58:4 path:+Docstrings
   addTypeDeclaration A Docstrings.re:61:4 path:+Docstrings.t
   addTypeDeclaration B Docstrings.re:62:4 path:+Docstrings.t
-  addValueDeclaration unitArgWithConversion Docstrings.re:65:4 path:+Docstrings
-  addValueDeclaration unitArgWithConversionU Docstrings.re:68:4 path:+Docstrings
+  addValueDeclaration +unitArgWithConversion Docstrings.re:65:4 path:+Docstrings
+  addValueDeclaration +unitArgWithConversionU Docstrings.re:68:4 path:+Docstrings
   addValueReference Docstrings.re:13:4 --> Docstrings.re:13:21
   addValueReference Docstrings.re:13:4 --> Docstrings.re:13:30
   addValueReference Docstrings.re:16:4 --> Docstrings.re:16:10
@@ -1538,10 +1538,10 @@
   addTypeReference Docstrings.re:65:34 --> Docstrings.re:61:4
   addTypeReference Docstrings.re:68:36 --> Docstrings.re:61:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TestFirstClassModules.cmt
-  addValueDeclaration convert TestFirstClassModules.re:2:4 path:+TestFirstClassModules
-  addValueDeclaration convertInterface TestFirstClassModules.re:5:4 path:+TestFirstClassModules
-  addValueDeclaration convertRecord TestFirstClassModules.re:8:4 path:+TestFirstClassModules
-  addValueDeclaration convertFirstClassModuleWithTypeEquations TestFirstClassModules.re:26:4 path:+TestFirstClassModules
+  addValueDeclaration +convert TestFirstClassModules.re:2:4 path:+TestFirstClassModules
+  addValueDeclaration +convertInterface TestFirstClassModules.re:5:4 path:+TestFirstClassModules
+  addValueDeclaration +convertRecord TestFirstClassModules.re:8:4 path:+TestFirstClassModules
+  addValueDeclaration +convertFirstClassModuleWithTypeEquations TestFirstClassModules.re:26:4 path:+TestFirstClassModules
   addValueReference TestFirstClassModules.re:2:4 --> TestFirstClassModules.re:2:15
   addValueReference TestFirstClassModules.re:5:4 --> TestFirstClassModules.re:5:24
   addValueReference TestFirstClassModules.re:8:4 --> TestFirstClassModules.re:8:21
@@ -1565,44 +1565,44 @@
   addValueDeclaration +x DeadCodeImplementation.re:2:6 path:+DeadCodeImplementation.M
   addValueReference DeadCodeInterface.re:1:17 --> DeadCodeImplementation.re:2:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTest.cmt
-  addValueDeclaration fortytwo DeadTest.re:2:4 path:+DeadTest
-  addValueDeclaration fortyTwoButExported DeadTest.re:5:4 path:+DeadTest
-  addValueDeclaration thisIsUsedOnce DeadTest.re:7:4 path:+DeadTest
-  addValueDeclaration thisIsUsedTwice DeadTest.re:10:4 path:+DeadTest
-  addValueDeclaration thisIsKeptAlive DeadTest.re:17:4 path:+DeadTest
-  addValueDeclaration thisIsMarkedLive DeadTest.re:20:4 path:+DeadTest
+  addValueDeclaration +fortytwo DeadTest.re:2:4 path:+DeadTest
+  addValueDeclaration +fortyTwoButExported DeadTest.re:5:4 path:+DeadTest
+  addValueDeclaration +thisIsUsedOnce DeadTest.re:7:4 path:+DeadTest
+  addValueDeclaration +thisIsUsedTwice DeadTest.re:10:4 path:+DeadTest
+  addValueDeclaration +thisIsKeptAlive DeadTest.re:17:4 path:+DeadTest
+  addValueDeclaration +thisIsMarkedLive DeadTest.re:20:4 path:+DeadTest
   addTypeDeclaration A DeadTest.re:36:6 path:+DeadTest.VariantUsedOnlyInImplementation.t
-  addValueDeclaration a DeadTest.re:37:2 path:+DeadTest.VariantUsedOnlyInImplementation
+  addValueDeclaration +a DeadTest.re:37:2 path:+DeadTest.VariantUsedOnlyInImplementation
   addTypeDeclaration xxx DeadTest.re:50:2 path:+DeadTest.record
   addTypeDeclaration yyy DeadTest.re:51:2 path:+DeadTest.record
-  addValueDeclaration x DeadTest.re:62:2 path:+DeadTest.MM
-  addValueDeclaration y DeadTest.re:63:2 path:+DeadTest.MM
-  addValueDeclaration unusedRec DeadTest.re:79:8 path:+DeadTest
-  addValueDeclaration split_map DeadTest.re:81:8 path:+DeadTest
-  addValueDeclaration rec1 DeadTest.re:86:8 path:+DeadTest
-  addValueDeclaration rec2 DeadTest.re:87:4 path:+DeadTest
-  addValueDeclaration recWithCallback DeadTest.re:89:8 path:+DeadTest
-  addValueDeclaration foo DeadTest.re:94:8 path:+DeadTest
-  addValueDeclaration bar DeadTest.re:98:4 path:+DeadTest
-  addValueDeclaration withDefaultValue DeadTest.re:100:4 path:+DeadTest
-  addValueDeclaration unsafe_string1 DeadTest.re:102:0 path:+DeadTest
-  addValueDeclaration unsafe_string2 DeadTest.re:105:2 path:+DeadTest.Ext_buffer
-  addValueDeclaration reasonResource DeadTest.re:112:40 path:+DeadTest.LazyDynamicallyLoadedComponent
-  addValueDeclaration makeProps DeadTest.re:112:40 path:+DeadTest.LazyDynamicallyLoadedComponent
-  addValueDeclaration make DeadTest.re:112:40 path:+DeadTest.LazyDynamicallyLoadedComponent
-  addValueDeclaration reasonResource DeadTest.re:119:6 path:+DeadTest.LazyDynamicallyLoadedComponent2
-  addValueDeclaration makeProps DeadTest.re:121:6 path:+DeadTest.LazyDynamicallyLoadedComponent2
-  addValueDeclaration make DeadTest.re:122:6 path:+DeadTest.LazyDynamicallyLoadedComponent2
-  addValueDeclaration cmp DeadTest.re:132:4 path:+DeadTest
-  addValueDeclaration cmp2 DeadTest.re:134:4 path:+DeadTest
-  addValueDeclaration zzz DeadTest.re:150:4 path:+DeadTest
-  addValueDeclaration second DeadTest.re:159:4 path:+DeadTest
-  addValueDeclaration minute DeadTest.re:160:4 path:+DeadTest
-  addValueDeclaration deadRef DeadTest.re:162:4 path:+DeadTest
-  addValueDeclaration makeSwitch DeadTest.re:164:4 path:+DeadTest
-  addValueDeclaration make DeadTest.re:167:4 path:+DeadTest
-  addValueDeclaration theSideEffectIsLogging DeadTest.re:171:4 path:+DeadTest
-  addValueDeclaration stringLengthNoSideEffects DeadTest.re:173:4 path:+DeadTest
+  addValueDeclaration +x DeadTest.re:62:2 path:+DeadTest.MM
+  addValueDeclaration +y DeadTest.re:63:2 path:+DeadTest.MM
+  addValueDeclaration +unusedRec DeadTest.re:79:8 path:+DeadTest
+  addValueDeclaration +split_map DeadTest.re:81:8 path:+DeadTest
+  addValueDeclaration +rec1 DeadTest.re:86:8 path:+DeadTest
+  addValueDeclaration +rec2 DeadTest.re:87:4 path:+DeadTest
+  addValueDeclaration +recWithCallback DeadTest.re:89:8 path:+DeadTest
+  addValueDeclaration +foo DeadTest.re:94:8 path:+DeadTest
+  addValueDeclaration +bar DeadTest.re:98:4 path:+DeadTest
+  addValueDeclaration +withDefaultValue DeadTest.re:100:4 path:+DeadTest
+  addValueDeclaration +unsafe_string1 DeadTest.re:102:0 path:+DeadTest
+  addValueDeclaration +unsafe_string2 DeadTest.re:105:2 path:+DeadTest.Ext_buffer
+  addValueDeclaration +reasonResource DeadTest.re:112:40 path:+DeadTest.LazyDynamicallyLoadedComponent
+  addValueDeclaration +makeProps DeadTest.re:112:40 path:+DeadTest.LazyDynamicallyLoadedComponent
+  addValueDeclaration +make DeadTest.re:112:40 path:+DeadTest.LazyDynamicallyLoadedComponent
+  addValueDeclaration +reasonResource DeadTest.re:119:6 path:+DeadTest.LazyDynamicallyLoadedComponent2
+  addValueDeclaration +makeProps DeadTest.re:121:6 path:+DeadTest.LazyDynamicallyLoadedComponent2
+  addValueDeclaration +make DeadTest.re:122:6 path:+DeadTest.LazyDynamicallyLoadedComponent2
+  addValueDeclaration +cmp DeadTest.re:132:4 path:+DeadTest
+  addValueDeclaration +cmp2 DeadTest.re:134:4 path:+DeadTest
+  addValueDeclaration +zzz DeadTest.re:150:4 path:+DeadTest
+  addValueDeclaration +second DeadTest.re:159:4 path:+DeadTest
+  addValueDeclaration +minute DeadTest.re:160:4 path:+DeadTest
+  addValueDeclaration +deadRef DeadTest.re:162:4 path:+DeadTest
+  addValueDeclaration +makeSwitch DeadTest.re:164:4 path:+DeadTest
+  addValueDeclaration +make DeadTest.re:167:4 path:+DeadTest
+  addValueDeclaration +theSideEffectIsLogging DeadTest.re:171:4 path:+DeadTest
+  addValueDeclaration +stringLengthNoSideEffects DeadTest.re:173:4 path:+DeadTest
   requireCond  true:+ExportWithRename false:+DynamicallyLoadedComponent allPositions:[DynamicallyLoadedComponent.re:2:4, ExportWithRename.re:3:4]
   addValueReference DeadTest:0:-1 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest:0:-1 --> ExportWithRename.re:3:4
@@ -1620,19 +1620,19 @@
   addTypeReference DeadTest.re:41:10 --> DeadTest.re:40:6
   addValueReference DeadTest.re:44:17 --> DeadTest.re:37:2
   addValueReference DeadTest.re:44:14 --> DeadTest.re:44:9
-  addValueDeclaration _ DeadTest.re:46:0 path:+DeadTest
+  addValueDeclaration +_ DeadTest.re:46:0 path:+DeadTest
   addTypeReference DeadTest.re:46:8 --> DeadTypeTest.rei:8:4
-  addValueDeclaration _ DeadTest.re:47:0 path:+DeadTest
+  addValueDeclaration +_ DeadTest.re:47:0 path:+DeadTest
   addTypeReference DeadTest.re:47:8 --> DeadTypeTest.rei:9:4
   addTypeDeclaration +xxx DeadTest.re:50:2 path:+DeadTest.+record
   addTypeDeclaration +yyy DeadTest.re:51:2 path:+DeadTest.+record
-  addValueDeclaration _ DeadTest.re:54:0 path:+DeadTest
+  addValueDeclaration +_ DeadTest.re:54:0 path:+DeadTest
   addTypeReference DeadTest.re:54:13 --> DeadTest.re:50:2
   addValueReference DeadTest.re:54:13 --> DeadTest.re:54:8
-  addValueDeclaration _ DeadTest.re:55:0 path:+DeadTest
+  addValueDeclaration +_ DeadTest.re:55:0 path:+DeadTest
   addValueReference DeadTest.re:55:19 --> DeadTest.re:55:10
   addTypeReference DeadTest.re:55:9 --> DeadTest.re:51:2
-  addValueDeclaration _ DeadTest.re:58:2 path:+DeadTest.UnderscoreInside
+  addValueDeclaration +_ DeadTest.re:58:2 path:+DeadTest.UnderscoreInside
   addValueDeclaration +y DeadTest.re:65:6 path:+DeadTest.MM
   addValueDeclaration +x DeadTest.re:66:6 path:+DeadTest.MM
   addValueReference DeadTest.re:66:6 --> DeadTest.re:65:6
@@ -1656,15 +1656,11 @@
   addValueReference DeadTest.re:100:4 --> DeadTest.re:100:45
   addValueDeclaration +unsafe_string2 DeadTest.re:107:2 path:+DeadTest.Ext_buffer
   addTypeReference DeadTest.re:110:16 --> DeadRT.rei:2:4
-  lazyLoad JSResource.jSResource(+DynamicallyLoadedComponent) JSResource.re:3:0 defined in DynamicallyLoadedComponent.re:2:4
-  addValueReference DeadTest.re:112:40 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest.re:112:40 --> JSResource.re:3:0
   addValueReference DeadTest.re:112:40 --> DeadTest.re:112:40
   addValueReference DeadTest.re:112:40 --> BootloaderResource.re:3:0
   addValueReference DeadTest.re:112:40 --> DeadTest.re:112:40
   addValueReference DeadTest.re:112:40 --> React.re:13:0
-  lazyLoad JSResource.jSResource(+DynamicallyLoadedComponent) JSResource.re:3:0 defined in DynamicallyLoadedComponent.re:2:4
-  addValueReference DeadTest.re:119:6 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest.re:119:6 --> JSResource.re:3:0
   addValueReference DeadTest.re:122:6 --> DeadTest.re:119:6
   addValueReference DeadTest.re:122:6 --> BootloaderResource.re:3:0
@@ -1680,12 +1676,10 @@
   addValueDeclaration +a1 DeadTest.re:151:6 path:+DeadTest
   addValueDeclaration +a2 DeadTest.re:152:6 path:+DeadTest
   addValueDeclaration +a3 DeadTest.re:153:6 path:+DeadTest
-  addValueReference DeadTest.re:157:17 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest.re:157:17 --> React.re:13:0
   addValueReference DeadTest.re:160:4 --> DeadTest.re:159:4
   addValueReference DeadTest.re:167:4 --> DeadTest.re:167:11
   addValueReference DeadTest.re:167:4 --> React.re:5:0
-  addValueReference DeadTest.re:169:16 --> DeadTest.re:167:4
   addValueReference DeadTest.re:37:2 --> DeadTest.re:41:6
   addValueReference DeadTest.re:62:2 --> DeadTest.re:66:6
   addValueReference DeadTest.re:63:2 --> DeadTest.re:65:6
@@ -1716,7 +1710,7 @@ File References
   Docstrings.re -->> 
   TestPromise.re -->> 
   ModuleAliases.re -->> 
-  DeadTest.re -->> React.re, BootloaderResource.re, DeadValueTest.rei, DynamicallyLoadedComponent.re, ImmutableArray.rei, JSResource.re
+  DeadTest.re -->> React.re, BootloaderResource.re, DeadValueTest.rei, ImmutableArray.rei, JSResource.re
   AutoAnnotate.re -->> 
   ImportHooks.re -->> 
   NestedModulesInSignature.rei -->> NestedModulesInSignature.re
@@ -1771,619 +1765,619 @@ File References
   Dead Type +AutoAnnotate.+r2.+r2: 0 references () [0]
   Dead Type +AutoAnnotate.+record.+variant: 0 references () [0]
   Dead Type +AutoAnnotate.+variant.+R: 0 references () [0]
-  Dead Value +BucklescriptAnnotations.bar: 0 references () [1]
+  Dead Value +BucklescriptAnnotations.+bar: 0 references () [1]
   Dead Value +BucklescriptAnnotations.+f: 0 references () [0]
-  Dead Value +BucklescriptAnnotations.foo: 0 references () [0]
-  Live Value +ComponentAsProp.make: 0 references () [0]
-  Live Value +ComponentAsProp.component: 1 references (ComponentAsProp.re:5:4) [0]
-  Live Value +CreateErrorHandler1.Error1.notification: 1 references (ErrorHandler.rei:3:2) [0]
-  Live Value +CreateErrorHandler2.Error2.notification: 1 references (ErrorHandler.rei:3:2) [0]
+  Dead Value +BucklescriptAnnotations.+foo: 0 references () [0]
+  Live Value +ComponentAsProp.+make: 0 references () [0]
+  Live Value +ComponentAsProp.+component: 1 references (ComponentAsProp.re:5:4) [0]
+  Live Value +CreateErrorHandler1.Error1.+notification: 1 references (ErrorHandler.rei:3:2) [0]
+  Live Value +CreateErrorHandler2.Error2.+notification: 1 references (ErrorHandler.rei:3:2) [0]
   Live Value +DeadCodeImplementation.M.+x: 1 references (DeadCodeInterface.re:1:17) [0]
-  Live Value +DeadMl.WithSignature.live11: 0 references () [0]
-  Dead Value +DeadMl.WithSignature.dead10: 0 references () [0]
-  Live Value +DeadMl.WithSignature.live9: 0 references () [0]
-  Dead Value +DeadMl.WithSignature.dead8: 0 references () [0]
+  Live Value +DeadMl.WithSignature.+live11: 0 references () [1]
   Live Value +DeadMl.WithSignature.+live11: 1 references (DeadMl.ml:103:2) [0]
+  Dead Value +DeadMl.WithSignature.+dead10: 0 references () [1]
   Dead Value +DeadMl.WithSignature.+dead10: 0 references () [0]
+  Live Value +DeadMl.WithSignature.+live9: 0 references () [1]
   Live Value +DeadMl.WithSignature.+live9: 1 references (DeadMl.ml:96:2) [0]
+  Dead Value +DeadMl.WithSignature.+dead8: 0 references () [1]
   Dead Value +DeadMl.WithSignature.+dead8: 0 references () [0]
-  Dead Value +DeadMl.dead7: 0 references () [0]
-  Live Value +DeadMl.live6: 0 references () [0]
-  Dead Value +DeadMl.dead5: 0 references () [0]
-  Live Value +DeadMl.live5: 0 references () [0]
-  Dead Value +DeadMl.dead4: 0 references () [0]
-  Live Value +DeadMl.Scope.live3: 0 references () [0]
-  Live Value +DeadMl.Scope.Inner2.liveInner3: 0 references () [0]
-  Dead Value +DeadMl.Scope.dead2: 0 references () [0]
-  Live Value +DeadMl.Scope.Inner1.liveInner2: 0 references () [0]
-  Dead Value +DeadMl.Scope.Inner1.deadInner1: 0 references () [0]
-  Dead Value +DeadMl.Scope.dead1: 0 references () [0]
-  Dead Value +DeadMl.inline_threshold: 0 references () [0]
-  Dead Value +DeadMl.map_split_opt: 0 references () [0]
+  Dead Value +DeadMl.+dead7: 0 references () [0]
+  Live Value +DeadMl.+live6: 0 references () [0]
+  Dead Value +DeadMl.+dead5: 0 references () [0]
+  Live Value +DeadMl.+live5: 0 references () [0]
+  Dead Value +DeadMl.+dead4: 0 references () [0]
+  Live Value +DeadMl.Scope.+live3: 0 references () [0]
+  Live Value +DeadMl.Scope.Inner2.+liveInner3: 0 references () [0]
+  Dead Value +DeadMl.Scope.+dead2: 0 references () [0]
+  Live Value +DeadMl.Scope.Inner1.+liveInner2: 0 references () [0]
+  Dead Value +DeadMl.Scope.Inner1.+deadInner1: 0 references () [0]
+  Dead Value +DeadMl.Scope.+dead1: 0 references () [0]
+  Dead Value +DeadMl.+inline_threshold: 0 references () [0]
+  Dead Value +DeadMl.+map_split_opt: 0 references () [0]
   Dead Type +DeadMl.+module_info.+case: 0 references () [0]
   Dead Type +DeadMl.+module_info.+module_name: 0 references () [0]
   Dead Type +DeadMl.+l.+Lfunction: 0 references () [0]
-  Dead Value +DeadMl.Bs_version.package_name: 0 references () [0]
-  Dead Value +DeadMl.Bs_version.header: 0 references () [0]
-  Dead Value +DeadMl.Bs_version.version: 0 references () [0]
+  Dead Value +DeadMl.Bs_version.+package_name: 0 references () [1]
   Dead Value +DeadMl.Bs_version.+package_name: 0 references () [0]
+  Dead Value +DeadMl.Bs_version.+header: 0 references () [1]
   Dead Value +DeadMl.Bs_version.+header: 0 references () [0]
+  Dead Value +DeadMl.Bs_version.+version: 0 references () [1]
   Dead Value +DeadMl.Bs_version.+version: 0 references () [0]
-  Dead Value +DeadMl._: 0 references () [0]
-  Dead Value +DeadMl._: 0 references () [0]
+  Dead Value +DeadMl.+_: 0 references () [0]
+  Dead Value +DeadMl.+_: 0 references () [0]
   Dead Type +DeadMl.+thisIsDead.+DeadB: 0 references () [0]
   Dead Type +DeadMl.+thisIsDead.+DeadA: 0 references () [0]
-  Dead Value +DeadMl.thisHasSemicolons: 0 references () [0]
-  Dead Value +DeadMl.AA.thisIsInInterface: 0 references () [0]
+  Dead Value +DeadMl.+thisHasSemicolons: 0 references () [0]
+  Dead Value +DeadMl.AA.+thisIsInInterface: 0 references () [1]
   Dead Value +DeadMl.AA.+thisIsInInterface: 0 references () [0]
-  Dead Value +DeadMl.QQ.thisSpansSeveralLines: 0 references () [0]
-  Dead Value +DeadRT.emitModuleAccessPath: 0 references () [0]
+  Dead Value +DeadMl.QQ.+thisSpansSeveralLines: 0 references () [0]
+  Dead Value +DeadRT.+emitModuleAccessPath: 0 references () [0]
   Live Type +DeadRT.+moduleAccessPath.+Kaboom: 1 references (DeadRT.re:11:16) [0]
   Dead Type +DeadRT.+moduleAccessPath.+Root: 0 references () [0]
   Dead Type DeadRT.moduleAccessPath.Kaboom: 0 references () [0]
   Live Type DeadRT.moduleAccessPath.Root: 1 references (DeadTest.re:110:16) [0]
-  Dead Value +DeadTest.stringLengthNoSideEffects: 0 references () [0]
-  Dead Value +DeadTest.theSideEffectIsLogging: 0 references () [0]
-  Live Value +DeadTest.make: 1 references (DeadTest.re:169:16) [0]
-  Dead Value +DeadTest.makeSwitch: 0 references () [0]
-  Dead Value +DeadTest.deadRef: 0 references () [0]
-  Dead Value +DeadTest.minute: 0 references () [0]
-  Dead Value +DeadTest.second: 0 references () [0]
+  Dead Value +DeadTest.+stringLengthNoSideEffects: 0 references () [0]
+  Dead Value +DeadTest.+theSideEffectIsLogging: 0 references () [0]
+  Dead Value +DeadTest.+make: 0 references () [0]
+  Dead Value +DeadTest.+makeSwitch: 0 references () [0]
+  Dead Value +DeadTest.+deadRef: 0 references () [0]
+  Dead Value +DeadTest.+minute: 0 references () [0]
+  Dead Value +DeadTest.+second: 0 references () [0]
   Dead Value +DeadTest.+a3: 0 references () [0]
   Dead Value +DeadTest.+a2: 0 references () [0]
   Dead Value +DeadTest.+a1: 0 references () [0]
-  Dead Value +DeadTest.zzz: 0 references () [0]
-  Dead Value +DeadTest.cmp2: 0 references () [0]
-  Live Value +DeadTest.cmp: 1 references (DeadTest.re:136:16) [0]
-  Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.make: 0 references () [0]
-  Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.makeProps: 0 references () [0]
-  Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.reasonResource: 0 references () [0]
-  Live Value +DeadTest.LazyDynamicallyLoadedComponent.make: 1 references (DeadTest.re:132:4) [0]
-  Dead Value +DeadTest.Ext_buffer.unsafe_string2: 0 references () [0]
+  Dead Value +DeadTest.+zzz: 0 references () [0]
+  Dead Value +DeadTest.+cmp2: 0 references () [0]
+  Live Value +DeadTest.+cmp: 1 references (DeadTest.re:136:16) [0]
+  Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.+make: 0 references () [0]
+  Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.+makeProps: 0 references () [0]
+  Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.+reasonResource: 0 references () [0]
+  Live Value +DeadTest.LazyDynamicallyLoadedComponent.+make: 1 references (DeadTest.re:132:4) [0]
+  Dead Value +DeadTest.Ext_buffer.+unsafe_string2: 0 references () [1]
   Dead Value +DeadTest.Ext_buffer.+unsafe_string2: 0 references () [0]
-  Dead Value +DeadTest.unsafe_string1: 0 references () [0]
-  Dead Value +DeadTest.withDefaultValue: 0 references () [0]
-  Dead Value +DeadTest.bar: 0 references () [0]
-  Dead Value +DeadTest.foo: 0 references () [1]
+  Dead Value +DeadTest.+unsafe_string1: 0 references () [0]
+  Dead Value +DeadTest.+withDefaultValue: 0 references () [0]
+  Dead Value +DeadTest.+bar: 0 references () [0]
+  Dead Value +DeadTest.+foo: 0 references () [1]
   Dead Value +DeadTest.+cb: 0 references () [0]
   Dead Value +DeadTest.+cb: 0 references () [0]
-  Dead Value +DeadTest.recWithCallback: 0 references () [0]
-  Dead Value +DeadTest.rec2: 0 references () [0]
-  Dead Value +DeadTest.rec1: 0 references () [0]
-  Dead Value +DeadTest.split_map: 0 references () [0]
-  Dead Value +DeadTest.unusedRec: 0 references () [0]
-  Dead Value +DeadTest.MM.y: 0 references () [0]
-  Live Value +DeadTest.MM.x: 1 references (DeadTest.re:73:9) [0]
+  Dead Value +DeadTest.+recWithCallback: 0 references () [0]
+  Dead Value +DeadTest.+rec2: 0 references () [0]
+  Dead Value +DeadTest.+rec1: 0 references () [0]
+  Dead Value +DeadTest.+split_map: 0 references () [0]
+  Dead Value +DeadTest.+unusedRec: 0 references () [0]
   Dead Value +DeadTest.MM.+valueOnlyInImplementation: 0 references () [0]
+  Live Value +DeadTest.MM.+x: 1 references (DeadTest.re:73:9) [1]
   Live Value +DeadTest.MM.+x: 1 references (DeadTest.re:62:2) [0]
+  Dead Value +DeadTest.MM.+y: 0 references () [1]
   Live Value +DeadTest.MM.+y: 1 references (DeadTest.re:66:6) [0]
-  Dead Value +DeadTest.UnderscoreInside._: 0 references () [0]
-  Dead Value +DeadTest._: 0 references () [0]
-  Dead Value +DeadTest._: 0 references () [0]
+  Dead Value +DeadTest.UnderscoreInside.+_: 0 references () [0]
+  Dead Value +DeadTest.+_: 0 references () [0]
+  Dead Value +DeadTest.+_: 0 references () [0]
   Live Type +DeadTest.+record.+yyy: 1 references (DeadTest.re:55:9) [0]
   Live Type +DeadTest.+record.+xxx: 1 references (DeadTest.re:54:13) [0]
-  Dead Value +DeadTest._: 0 references () [0]
-  Dead Value +DeadTest._: 0 references () [0]
-  Live Value +DeadTest.VariantUsedOnlyInImplementation.a: 1 references (DeadTest.re:44:17) [0]
+  Dead Value +DeadTest.+_: 0 references () [0]
+  Dead Value +DeadTest.+_: 0 references () [0]
+  Live Value +DeadTest.VariantUsedOnlyInImplementation.+a: 1 references (DeadTest.re:44:17) [1]
   Live Value +DeadTest.VariantUsedOnlyInImplementation.+a: 1 references (DeadTest.re:37:2) [0]
   Live Type +DeadTest.VariantUsedOnlyInImplementation.+t.+A: 1 references (DeadTest.re:41:10) [0]
   Live Type +DeadTest.VariantUsedOnlyInImplementation.t.A: 1 references (DeadTest.re:40:6) [0]
   Dead Value +DeadTest.M.+thisSignatureItemIsDead: 0 references () [0]
-  Live Value +DeadTest.thisIsMarkedLive: 0 references () [0]
-  Live Value +DeadTest.thisIsKeptAlive: 1 references (DeadTest.re:20:4) [0]
-  Live Value +DeadTest.thisIsUsedTwice: 2 references (DeadTest.re:11:7, DeadTest.re:12:7) [0]
-  Live Value +DeadTest.thisIsUsedOnce: 1 references (DeadTest.re:8:7) [0]
-  Live Value +DeadTest.fortyTwoButExported: 0 references () [0]
-  Dead Value +DeadTest.fortytwo: 0 references () [0]
-  Dead Value +DeadTestBlacklist.x: 0 references () [0]
-  Dead Value +DeadTestWithInterface.Ext_buffer.x: 0 references () [0]
+  Live Value +DeadTest.+thisIsMarkedLive: 0 references () [0]
+  Live Value +DeadTest.+thisIsKeptAlive: 1 references (DeadTest.re:20:4) [0]
+  Live Value +DeadTest.+thisIsUsedTwice: 2 references (DeadTest.re:11:7, DeadTest.re:12:7) [0]
+  Live Value +DeadTest.+thisIsUsedOnce: 1 references (DeadTest.re:8:7) [0]
+  Live Value +DeadTest.+fortyTwoButExported: 0 references () [0]
+  Dead Value +DeadTest.+fortytwo: 0 references () [0]
+  Dead Value +DeadTestBlacklist.+x: 0 references () [0]
+  Dead Value +DeadTestWithInterface.Ext_buffer.+x: 0 references () [1]
   Dead Value +DeadTestWithInterface.Ext_buffer.+x: 0 references () [0]
   Dead Type DeadTypeTest.deadType.InNeither: 0 references () [0]
   Live Type DeadTypeTest.deadType.InBoth: 1 references (DeadTest.re:47:8) [0]
   Live Type DeadTypeTest.deadType.OnlyInInterface: 1 references (DeadTest.re:46:8) [0]
   Dead Type DeadTypeTest.deadType.OnlyInImplementation: 0 references () [0]
-  Dead Value DeadTypeTest.a: 0 references () [0]
+  Dead Value DeadTypeTest.+a: 0 references () [0]
   Dead Type DeadTypeTest.t.B: 0 references () [0]
   Dead Type DeadTypeTest.t.A: 0 references () [0]
-  Live Value +Docstrings.unitArgWithConversionU: 0 references () [0]
-  Live Value +Docstrings.unitArgWithConversion: 0 references () [0]
+  Live Value +Docstrings.+unitArgWithConversionU: 0 references () [0]
+  Live Value +Docstrings.+unitArgWithConversion: 0 references () [0]
   Dead Type +Docstrings.+t.+B: 0 references () [0]
   Live Type +Docstrings.+t.+A: 2 references (Docstrings.re:65:34, Docstrings.re:68:36) [0]
-  Live Value +Docstrings.unitArgWithoutConversionU: 0 references () [0]
-  Live Value +Docstrings.unitArgWithoutConversion: 0 references () [0]
-  Live Value +Docstrings.grouped: 0 references () [0]
-  Live Value +Docstrings.unnamed2U: 0 references () [0]
-  Live Value +Docstrings.unnamed2: 0 references () [0]
-  Live Value +Docstrings.unnamed1U: 0 references () [0]
-  Live Value +Docstrings.unnamed1: 0 references () [0]
-  Live Value +Docstrings.useParamU: 0 references () [0]
-  Live Value +Docstrings.useParam: 0 references () [0]
-  Live Value +Docstrings.treeU: 0 references () [0]
-  Live Value +Docstrings.twoU: 0 references () [0]
-  Live Value +Docstrings.oneU: 0 references () [0]
-  Live Value +Docstrings.tree: 0 references () [0]
-  Live Value +Docstrings.two: 0 references () [0]
-  Live Value +Docstrings.one: 0 references () [0]
-  Live Value +Docstrings.signMessage: 0 references () [0]
-  Live Value +Docstrings.flat: 0 references () [0]
-  Live Value +ExportWithRename.make: 1 references (DeadTest:0:-1) [0]
-  Live Value +FirstClassModules.someFunctorAsFunction: 0 references () [0]
+  Live Value +Docstrings.+unitArgWithoutConversionU: 0 references () [0]
+  Live Value +Docstrings.+unitArgWithoutConversion: 0 references () [0]
+  Live Value +Docstrings.+grouped: 0 references () [0]
+  Live Value +Docstrings.+unnamed2U: 0 references () [0]
+  Live Value +Docstrings.+unnamed2: 0 references () [0]
+  Live Value +Docstrings.+unnamed1U: 0 references () [0]
+  Live Value +Docstrings.+unnamed1: 0 references () [0]
+  Live Value +Docstrings.+useParamU: 0 references () [0]
+  Live Value +Docstrings.+useParam: 0 references () [0]
+  Live Value +Docstrings.+treeU: 0 references () [0]
+  Live Value +Docstrings.+twoU: 0 references () [0]
+  Live Value +Docstrings.+oneU: 0 references () [0]
+  Live Value +Docstrings.+tree: 0 references () [0]
+  Live Value +Docstrings.+two: 0 references () [0]
+  Live Value +Docstrings.+one: 0 references () [0]
+  Live Value +Docstrings.+signMessage: 0 references () [0]
+  Live Value +Docstrings.+flat: 0 references () [0]
+  Live Value +DynamicallyLoadedComponent.+make: 1 references (DeadTest:0:-1) [0]
+  Live Value +ExportWithRename.+make: 1 references (DeadTest:0:-1) [0]
+  Live Value +FirstClassModules.+someFunctorAsFunction: 0 references () [0]
   Live Value +FirstClassModules.SomeFunctor.+ww: 1 references (FirstClassModules.re:46:20) [0]
-  Live Value +FirstClassModules.testConvert: 0 references () [0]
-  Live Value +FirstClassModules.firstClassModule: 0 references () [0]
-  Live Value +FirstClassModules.M.x: 1 references (FirstClassModules.re:2:2) [0]
-  Live Value +FirstClassModules.M.f: 1 references (FirstClassModules.re:4:2) [0]
-  Live Value +FirstClassModules.M.Z.u: 1 references (FirstClassModules.re:28:20) [0]
-  Live Value +FirstClassModules.M.InnerModule3.k3: 1 references (FirstClassModules.re:10:4) [0]
-  Live Value +FirstClassModules.M.InnerModule2.k: 1 references (FirstClassModules.re:7:24) [0]
-  Live Value +FirstClassModules.M.y: 1 references (FirstClassModules.re:14:2) [0]
-  Dead Value FirstClassModulesInterface.r: 0 references () [0]
+  Live Value +FirstClassModules.+testConvert: 0 references () [0]
+  Live Value +FirstClassModules.+firstClassModule: 0 references () [0]
+  Live Value +FirstClassModules.M.+x: 1 references (FirstClassModules.re:2:2) [0]
+  Live Value +FirstClassModules.M.+f: 1 references (FirstClassModules.re:4:2) [0]
+  Live Value +FirstClassModules.M.Z.+u: 1 references (FirstClassModules.re:28:20) [0]
+  Live Value +FirstClassModules.M.InnerModule3.+k3: 1 references (FirstClassModules.re:10:4) [0]
+  Live Value +FirstClassModules.M.InnerModule2.+k: 1 references (FirstClassModules.re:7:24) [0]
+  Live Value +FirstClassModules.M.+y: 1 references (FirstClassModules.re:14:2) [0]
+  Dead Value FirstClassModulesInterface.+r: 0 references () [0]
   Dead Type FirstClassModulesInterface.record.y: 0 references () [0]
   Dead Type FirstClassModulesInterface.record.x: 0 references () [0]
-  Dead Value +Hooks.aComponentWithChildren: 0 references () [0]
+  Dead Value +Hooks.+aComponentWithChildren: 0 references () [0]
   Dead Value +Hooks.RenderPropRequiresConversion.+make: 0 references () [1]
   Dead Value +Hooks.RenderPropRequiresConversion.+unsafe_expr: 0 references () [0]
   Dead Value +Hooks.RenderPropRequiresConversion.+car: 0 references () [0]
-  Dead Value +Hooks.functionReturningReactElement: 0 references () [0]
-  Dead Value +Hooks.polymorphicComponent: 0 references () [0]
-  Dead Value +Hooks.input: 0 references () [0]
+  Dead Value +Hooks.+functionReturningReactElement: 0 references () [0]
+  Dead Value +Hooks.+polymorphicComponent: 0 references () [0]
+  Dead Value +Hooks.+input: 0 references () [0]
   Live Type +Hooks.+r.+x: 1 references (Hooks.re:113:45) [0]
-  Live Value +Hooks.testForwardRef: 0 references () [0]
-  Dead Value +Hooks.makeWithRef: 0 references () [0]
-  Dead Value +Hooks.componentWithRenamedArgs: 0 references () [0]
-  Live Value +Hooks.functionWithRenamedArgs: 0 references () [0]
+  Live Value +Hooks.+testForwardRef: 0 references () [0]
+  Dead Value +Hooks.+makeWithRef: 0 references () [0]
+  Dead Value +Hooks.+componentWithRenamedArgs: 0 references () [0]
+  Live Value +Hooks.+functionWithRenamedArgs: 0 references () [0]
   Dead Value +Hooks.NoProps.+make: 0 references () [0]
   Dead Value +Hooks.Inner.Inner2.+anotherComponent: 0 references () [0]
   Dead Value +Hooks.Inner.Inner2.+make: 0 references () [0]
   Dead Value +Hooks.Inner.+anotherComponent: 0 references () [0]
   Dead Value +Hooks.Inner.+make: 0 references () [0]
-  Dead Value +Hooks.anotherComponent: 0 references () [0]
-  Live Value +Hooks.default: 0 references () [0]
-  Dead Value +Hooks.make: 0 references () [0]
+  Dead Value +Hooks.+anotherComponent: 0 references () [0]
+  Live Value +Hooks.+default: 0 references () [0]
+  Dead Value +Hooks.+make: 0 references () [0]
   Live Type +Hooks.+vehicle.+name: 13 references (Hooks.re:11:12, Hooks.re:42:41, Hooks.re:49:43, Hooks.re:54:43, Hooks.re:60:45, Hooks.re:65:45, Hooks.re:82:2, Hooks.re:82:14, Hooks.re:89:15, Hooks.re:89:27, Hooks.re:98:20, Hooks.re:130:58, Hooks.re:158:37) [0]
-  Live Value +ImportIndex.make: 0 references () [0]
-  Live Value +LetPrivate.y: 0 references () [0]
+  Live Value +ImportIndex.+make: 0 references () [0]
+  Live Value +LetPrivate.+y: 0 references () [0]
   Live Value +LetPrivate.local_1.+x: 1 references (LetPrivate.re:5:4) [0]
-  Live Value +ManyComponents.make: 0 references () [1]
+  Live Value +ManyComponents.+make: 0 references () [1]
   Live Value +ManyComponents.+emptyArray: 1 references (ManyComponents.re:39:4) [0]
-  Live Value +ManyComponents.component: 1 references (ManyComponents.re:39:4) [0]
-  Live Value +ManyComponents.ManyProps.make: 0 references () [0]
-  Live Value +ManyComponents.ManyProps.component: 1 references (ManyComponents.re:19:6) [0]
-  Live Value +ManyComponents.InnerComponent.make: 1 references (ManyComponents.re:39:4) [0]
-  Live Value +ManyComponents.InnerComponent.component: 1 references (ManyComponents.re:9:6) [0]
-  Dead Value +ManyComponents.InnerComponent.someValueSoModuleOffsetsAreShifted: 0 references () [0]
-  Live Value +ModuleAliases.testInner2: 0 references () [0]
-  Live Value +ModuleAliases.testInner: 0 references () [0]
-  Live Value +ModuleAliases.testNested: 0 references () [0]
+  Live Value +ManyComponents.+component: 1 references (ManyComponents.re:39:4) [0]
+  Live Value +ManyComponents.ManyProps.+make: 0 references () [0]
+  Live Value +ManyComponents.ManyProps.+component: 1 references (ManyComponents.re:19:6) [0]
+  Live Value +ManyComponents.InnerComponent.+make: 1 references (ManyComponents.re:39:4) [0]
+  Live Value +ManyComponents.InnerComponent.+component: 1 references (ManyComponents.re:9:6) [0]
+  Dead Value +ManyComponents.InnerComponent.+someValueSoModuleOffsetsAreShifted: 0 references () [0]
+  Live Value +ModuleAliases.+testInner2: 0 references () [0]
+  Live Value +ModuleAliases.+testInner: 0 references () [0]
+  Live Value +ModuleAliases.+testNested: 0 references () [0]
   Dead Type +ModuleAliases.Outer2.Inner2.InnerNested.+t.+nested: 0 references () [0]
   Dead Type +ModuleAliases.Outer.Inner.+innerT.+inner: 0 references () [0]
-  Dead Value +ModuleAliases2.q: 0 references () [0]
+  Dead Value +ModuleAliases2.+q: 0 references () [0]
   Dead Type +ModuleAliases2.Outer.Inner.+inner.+inner: 0 references () [0]
   Dead Type +ModuleAliases2.Outer.+outer.+outer: 0 references () [0]
   Dead Type +ModuleAliases2.+record.+y: 0 references () [0]
   Dead Type +ModuleAliases2.+record.+x: 0 references () [0]
-  Live Value +NestedModules.Universe.someString: 0 references () [0]
+  Live Value +NestedModules.Universe.+someString: 0 references () [0]
   Dead Type +NestedModules.Universe.+variant.+B: 0 references () [0]
   Dead Type +NestedModules.Universe.+variant.+A: 0 references () [0]
-  Live Value +NestedModules.Universe.Nested2.nested2Function: 0 references () [0]
-  Live Value +NestedModules.Universe.Nested2.Nested3.nested3Function: 0 references () [0]
-  Live Value +NestedModules.Universe.Nested2.Nested3.nested3Value: 0 references () [0]
-  Dead Value +NestedModules.Universe.Nested2.Nested3.w: 0 references () [0]
-  Dead Value +NestedModules.Universe.Nested2.Nested3.z: 0 references () [0]
-  Dead Value +NestedModules.Universe.Nested2.Nested3.y: 0 references () [0]
-  Dead Value +NestedModules.Universe.Nested2.Nested3.x: 0 references () [0]
-  Dead Value +NestedModules.Universe.Nested2.y: 0 references () [0]
-  Live Value +NestedModules.Universe.Nested2.nested2Value: 0 references () [0]
-  Dead Value +NestedModules.Universe.Nested2.x: 0 references () [0]
-  Dead Value +NestedModules.Universe.notExported: 0 references () [0]
-  Live Value +NestedModules.Universe.theAnswer: 0 references () [0]
-  Live Value +NestedModules.notNested: 0 references () [0]
-  Live Value NestedModulesInSignature.Universe.theAnswer: 0 references () [0]
-  Live Value +Opaque.testConvertNestedRecordFromOtherFile: 0 references () [0]
-  Live Value +Opaque.noConversion: 0 references () [0]
+  Live Value +NestedModules.Universe.Nested2.+nested2Function: 0 references () [0]
+  Live Value +NestedModules.Universe.Nested2.Nested3.+nested3Function: 0 references () [0]
+  Live Value +NestedModules.Universe.Nested2.Nested3.+nested3Value: 0 references () [0]
+  Dead Value +NestedModules.Universe.Nested2.Nested3.+w: 0 references () [0]
+  Dead Value +NestedModules.Universe.Nested2.Nested3.+z: 0 references () [0]
+  Dead Value +NestedModules.Universe.Nested2.Nested3.+y: 0 references () [0]
+  Dead Value +NestedModules.Universe.Nested2.Nested3.+x: 0 references () [0]
+  Dead Value +NestedModules.Universe.Nested2.+y: 0 references () [0]
+  Live Value +NestedModules.Universe.Nested2.+nested2Value: 0 references () [0]
+  Dead Value +NestedModules.Universe.Nested2.+x: 0 references () [0]
+  Dead Value +NestedModules.Universe.+notExported: 0 references () [0]
+  Live Value +NestedModules.Universe.+theAnswer: 0 references () [0]
+  Live Value +NestedModules.+notNested: 0 references () [0]
+  Live Value NestedModulesInSignature.Universe.+theAnswer: 0 references () [0]
+  Live Value +Opaque.+testConvertNestedRecordFromOtherFile: 0 references () [0]
+  Live Value +Opaque.+noConversion: 0 references () [0]
   Dead Type +Opaque.+opaqueFromRecords.+A: 0 references () [0]
-  Live Value +ReasonComponent.useRecordsCoord: 0 references () [0]
-  Live Value +ReasonComponent.tToString: 0 references () [0]
+  Live Value +ReasonComponent.+useRecordsCoord: 0 references () [0]
+  Live Value +ReasonComponent.+tToString: 0 references () [0]
   Dead Type +ReasonComponent.+t.+C: 0 references () [0]
   Dead Type +ReasonComponent.+t.+B: 0 references () [0]
   Dead Type +ReasonComponent.+t.+A: 0 references () [0]
-  Live Value +ReasonComponent.useTypeDefinedInAnotherModule: 0 references () [0]
-  Live Value +ReasonComponent.minus: 0 references () [0]
-  Live Value +ReasonComponent.make: 0 references () [1]
+  Live Value +ReasonComponent.+useTypeDefinedInAnotherModule: 0 references () [0]
+  Live Value +ReasonComponent.+minus: 0 references () [0]
+  Live Value +ReasonComponent.+make: 0 references () [1]
   Live Value +ReasonComponent.+emptyArray: 1 references (ReasonComponent.re:18:4) [0]
-  Live Value +ReasonComponent.onClick: 1 references (ReasonComponent.re:18:4) [0]
+  Live Value +ReasonComponent.+onClick: 1 references (ReasonComponent.re:18:4) [0]
   Dead Type +ReasonComponent.+person.+polymorphicPayload: 0 references () [0]
   Dead Type +ReasonComponent.+person.+type_: 0 references () [0]
   Dead Type +ReasonComponent.+person.+surname: 0 references () [0]
   Live Type +ReasonComponent.+person.+name: 1 references (ReasonComponent.re:32:12) [0]
-  Live Value +ReasonComponent.component: 1 references (ReasonComponent.re:18:4) [0]
-  Live Value +Records.testMyRecBsAs2: 0 references () [0]
-  Live Value +Records.testMyRecBsAs: 0 references () [0]
+  Live Value +ReasonComponent.+component: 1 references (ReasonComponent.re:18:4) [0]
+  Live Value +Records.+testMyRecBsAs2: 0 references () [0]
+  Live Value +Records.+testMyRecBsAs: 0 references () [0]
   Live Type +Records.+myRecBsAs.+type_: 1 references (Records.re:167:38) [0]
-  Live Value +Records.testMyObj2: 0 references () [0]
-  Live Value +Records.testMyObj: 0 references () [0]
-  Live Value +Records.testMyRec2: 0 references () [0]
-  Live Value +Records.testMyRec: 0 references () [0]
+  Live Value +Records.+testMyObj2: 0 references () [0]
+  Live Value +Records.+testMyObj: 0 references () [0]
+  Live Value +Records.+testMyRec2: 0 references () [0]
+  Live Value +Records.+testMyRec: 0 references () [0]
   Live Type +Records.+myRec.+type_: 1 references (Records.re:149:30) [0]
-  Live Value +Records.computeArea4: 0 references () [0]
-  Live Value +Records.computeArea3: 0 references () [0]
-  Live Value +Records.someBusiness2: 0 references () [0]
-  Live Value +Records.findAddress2: 0 references () [0]
+  Live Value +Records.+computeArea4: 0 references () [0]
+  Live Value +Records.+computeArea3: 0 references () [0]
+  Live Value +Records.+someBusiness2: 0 references () [0]
+  Live Value +Records.+findAddress2: 0 references () [0]
   Live Type +Records.+business2.+address2: 1 references (Records.re:93:2) [0]
   Dead Type +Records.+business2.+owner: 0 references () [0]
   Dead Type +Records.+business2.+name: 0 references () [0]
-  Live Value +Records.getPayloadRecordPlusOne: 0 references () [0]
-  Live Value +Records.payloadValue: 0 references () [0]
-  Live Value +Records.recordValue: 1 references (Records.re:76:4) [0]
-  Live Value +Records.getPayloadRecord: 0 references () [0]
+  Live Value +Records.+getPayloadRecordPlusOne: 0 references () [0]
+  Live Value +Records.+payloadValue: 0 references () [0]
+  Live Value +Records.+recordValue: 1 references (Records.re:76:4) [0]
+  Live Value +Records.+getPayloadRecord: 0 references () [0]
   Dead Type +Records.+record.+w: 0 references () [0]
   Live Type +Records.+record.+v: 1 references (Records.re:81:5) [0]
-  Live Value +Records.getPayload: 0 references () [0]
+  Live Value +Records.+getPayload: 0 references () [0]
   Live Type +Records.+payload.+payload: 3 references (Records.re:61:18, Records.re:70:24, Records.re:79:31) [0]
   Dead Type +Records.+payload.+num: 0 references () [0]
-  Live Value +Records.findAllAddresses: 0 references () [0]
-  Live Value +Records.someBusiness: 0 references () [0]
-  Live Value +Records.findAddress: 0 references () [0]
-  Live Value +Records.getOpt: 3 references (Records.re:37:4, Records.re:44:4, Records.re:92:4) [0]
+  Live Value +Records.+findAllAddresses: 0 references () [0]
+  Live Value +Records.+someBusiness: 0 references () [0]
+  Live Value +Records.+findAddress: 0 references () [0]
+  Live Value +Records.+getOpt: 3 references (Records.re:37:4, Records.re:44:4, Records.re:92:4) [0]
   Live Type +Records.+business.+address: 2 references (Records.re:38:2, Records.re:47:6) [0]
   Live Type +Records.+business.+owner: 1 references (Records.re:48:8) [0]
   Dead Type +Records.+business.+name: 0 references () [0]
   Live Type +Records.+person.+address: 1 references (Records.re:48:40) [0]
   Dead Type +Records.+person.+age: 0 references () [0]
   Dead Type +Records.+person.+name: 0 references () [0]
-  Live Value +Records.coord2d: 0 references () [0]
-  Live Value +Records.computeArea: 0 references () [0]
-  Live Value +Records.origin: 0 references () [0]
+  Live Value +Records.+coord2d: 0 references () [0]
+  Live Value +Records.+computeArea: 0 references () [0]
+  Live Value +Records.+origin: 0 references () [0]
   Live Type +Records.+coord.+z: 1 references (Records.re:14:19) [0]
   Live Type +Records.+coord.+y: 2 references (ReasonComponent.re:63:23, Records.re:14:19) [0]
   Live Type +Records.+coord.+x: 2 references (ReasonComponent.re:63:23, Records.re:14:19) [0]
-  Live Value +References.preserveRefIdentity: 0 references () [0]
-  Live Value +References.destroysRefIdentity: 0 references () [0]
+  Live Value +References.+preserveRefIdentity: 0 references () [0]
+  Live Value +References.+destroysRefIdentity: 0 references () [0]
   Dead Type +References.+requiresConversion.+x: 0 references () [0]
-  Live Value +References.set: 0 references () [0]
-  Live Value +References.make: 0 references () [0]
-  Live Value +References.get: 0 references () [0]
-  Live Value +References.R.set: 1 references (References.re:37:4) [0]
-  Live Value +References.R.make: 1 references (References.re:34:4) [0]
-  Live Value +References.R.get: 1 references (References.re:31:4) [0]
+  Live Value +References.+set: 0 references () [0]
+  Live Value +References.+make: 0 references () [0]
+  Live Value +References.+get: 0 references () [0]
+  Live Value +References.R.+set: 1 references (References.re:37:4) [1]
   Live Value +References.R.+set: 1 references (References.re:19:2) [0]
+  Live Value +References.R.+make: 1 references (References.re:34:4) [1]
   Live Value +References.R.+make: 1 references (References.re:18:2) [0]
+  Live Value +References.R.+get: 1 references (References.re:31:4) [1]
   Live Value +References.R.+get: 1 references (References.re:17:2) [0]
-  Live Value +References.update: 0 references () [0]
-  Live Value +References.access: 0 references () [0]
-  Live Value +References.create: 0 references () [0]
-  Dead Value +RequireCond.either: 0 references () [0]
-  Dead Value +RequireCond.make: 0 references () [0]
-  Dead Value +Shadow.M.test: 0 references () [0]
+  Live Value +References.+update: 0 references () [0]
+  Live Value +References.+access: 0 references () [0]
+  Live Value +References.+create: 0 references () [0]
+  Dead Value +RequireCond.+either: 0 references () [0]
+  Dead Value +RequireCond.+make: 0 references () [0]
+  Dead Value +Shadow.M.+test: 0 references () [0]
   Live Value +Shadow.M.+test: 0 references () [0]
-  Live Value +Shadow.test: 0 references () [0]
-  Live Value +Shadow.test: 0 references () [0]
-  Live Value +TestEmitInnerModules.Outer.Medium.Inner.y: 0 references () [0]
-  Live Value +TestEmitInnerModules.Inner.y: 0 references () [0]
-  Live Value +TestEmitInnerModules.Inner.x: 0 references () [0]
-  Live Value +TestFirstClassModules.convertFirstClassModuleWithTypeEquations: 0 references () [0]
-  Live Value +TestFirstClassModules.convertRecord: 0 references () [0]
-  Live Value +TestFirstClassModules.convertInterface: 0 references () [0]
-  Live Value +TestFirstClassModules.convert: 0 references () [0]
-  Dead Value +TestImmutableArray.testBeltArraySet: 0 references () [0]
-  Dead Value +TestImmutableArray.testBeltArrayGet: 0 references () [0]
-  Live Value +TestImmutableArray.testImmutableArrayGet: 0 references () [0]
-  Live Value +TestImport.defaultValue2: 0 references () [0]
-  Dead Value +TestImport.make: 0 references () [0]
-  Live Value +TestImport.make: 0 references () [0]
+  Live Value +Shadow.+test: 0 references () [0]
+  Live Value +Shadow.+test: 0 references () [0]
+  Live Value +TestEmitInnerModules.Outer.Medium.Inner.+y: 0 references () [0]
+  Live Value +TestEmitInnerModules.Inner.+y: 0 references () [0]
+  Live Value +TestEmitInnerModules.Inner.+x: 0 references () [0]
+  Live Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquations: 0 references () [0]
+  Live Value +TestFirstClassModules.+convertRecord: 0 references () [0]
+  Live Value +TestFirstClassModules.+convertInterface: 0 references () [0]
+  Live Value +TestFirstClassModules.+convert: 0 references () [0]
+  Dead Value +TestImmutableArray.+testBeltArraySet: 0 references () [0]
+  Dead Value +TestImmutableArray.+testBeltArrayGet: 0 references () [0]
+  Live Value +TestImmutableArray.+testImmutableArrayGet: 0 references () [0]
+  Live Value +TestImport.+defaultValue2: 0 references () [0]
+  Dead Value +TestImport.+make: 0 references () [0]
+  Live Value +TestImport.+make: 0 references () [0]
   Dead Type +TestImport.+message.+text: 0 references () [0]
-  Live Value +TestImport.defaultValue: 0 references () [0]
-  Live Value +TestImport.valueStartingWithUpperCaseLetter: 0 references () [0]
-  Dead Value +TestImport.innerStuffContents: 0 references () [0]
-  Live Value +TestImport.innerStuffContentsAsEmptyObject: 0 references () [0]
-  Live Value +TestImport.innerStuffContents: 0 references () [0]
-  Live Value +TestModuleAliases.testInner2Expanded: 0 references () [0]
-  Live Value +TestModuleAliases.testInner2: 0 references () [0]
-  Live Value +TestModuleAliases.testInner1Expanded: 0 references () [0]
-  Live Value +TestModuleAliases.testInner1: 0 references () [0]
-  Live Value +TestPromise.convert: 0 references () [0]
+  Live Value +TestImport.+defaultValue: 0 references () [0]
+  Live Value +TestImport.+valueStartingWithUpperCaseLetter: 0 references () [0]
+  Dead Value +TestImport.+innerStuffContents: 0 references () [0]
+  Live Value +TestImport.+innerStuffContentsAsEmptyObject: 0 references () [0]
+  Live Value +TestImport.+innerStuffContents: 0 references () [0]
+  Live Value +TestModuleAliases.+testInner2Expanded: 0 references () [0]
+  Live Value +TestModuleAliases.+testInner2: 0 references () [0]
+  Live Value +TestModuleAliases.+testInner1Expanded: 0 references () [0]
+  Live Value +TestModuleAliases.+testInner1: 0 references () [0]
+  Live Value +TestPromise.+convert: 0 references () [0]
   Dead Type +TestPromise.+toPayload.+result: 0 references () [0]
   Live Type +TestPromise.+fromPayload.+s: 1 references (TestPromise.re:14:32) [0]
   Dead Type +TestPromise.+fromPayload.+x: 0 references () [0]
-  Live Value +TransitiveType1.convertAlias: 0 references () [0]
-  Live Value +TransitiveType1.convert: 0 references () [0]
-  Dead Value +TransitiveType2.convertT2: 0 references () [0]
-  Live Value +TransitiveType3.convertT3: 0 references () [0]
+  Live Value +TransitiveType1.+convertAlias: 0 references () [0]
+  Live Value +TransitiveType1.+convert: 0 references () [0]
+  Dead Value +TransitiveType2.+convertT2: 0 references () [0]
+  Live Value +TransitiveType3.+convertT3: 0 references () [0]
   Dead Type +TransitiveType3.+t3.+s: 0 references () [0]
   Dead Type +TransitiveType3.+t3.+i: 0 references () [0]
-  Live Value +Tuples.changeSecondAge: 0 references () [0]
-  Live Value +Tuples.marry: 0 references () [0]
-  Live Value +Tuples.getFirstName: 0 references () [0]
+  Live Value +Tuples.+changeSecondAge: 0 references () [0]
+  Live Value +Tuples.+marry: 0 references () [0]
+  Live Value +Tuples.+getFirstName: 0 references () [0]
   Live Type +Tuples.+person.+age: 1 references (Tuples.re:47:19) [0]
   Live Type +Tuples.+person.+name: 1 references (Tuples.re:39:49) [0]
-  Live Value +Tuples.coord2d: 0 references () [0]
-  Live Value +Tuples.computeAreaNoConverters: 0 references () [0]
-  Live Value +Tuples.computeAreaWithIdent: 0 references () [0]
-  Live Value +Tuples.computeArea: 0 references () [0]
-  Live Value +Tuples.origin: 0 references () [0]
-  Live Value +Tuples.testTuple: 0 references () [0]
-  Dead Value +TypeParams1.exportSomething: 0 references () [0]
-  Dead Value +TypeParams2.exportSomething: 0 references () [0]
+  Live Value +Tuples.+coord2d: 0 references () [0]
+  Live Value +Tuples.+computeAreaNoConverters: 0 references () [0]
+  Live Value +Tuples.+computeAreaWithIdent: 0 references () [0]
+  Live Value +Tuples.+computeArea: 0 references () [0]
+  Live Value +Tuples.+origin: 0 references () [0]
+  Live Value +Tuples.+testTuple: 0 references () [0]
+  Dead Value +TypeParams1.+exportSomething: 0 references () [0]
+  Dead Value +TypeParams2.+exportSomething: 0 references () [0]
   Dead Type +TypeParams2.+item.+id: 0 references () [0]
-  Live Value +TypeParams3.test2: 0 references () [0]
-  Live Value +TypeParams3.test: 0 references () [0]
+  Live Value +TypeParams3.+test2: 0 references () [0]
+  Live Value +TypeParams3.+test: 0 references () [0]
   Dead Value +Types.ObjectId.+x: 0 references () [0]
-  Live Value +Types.optFunction: 0 references () [0]
-  Live Value +Types.i64Const: 0 references () [0]
-  Live Value +Types.currentTime: 0 references () [0]
-  Live Value +Types.testInstantiateTypeParameter: 0 references () [0]
+  Live Value +Types.+optFunction: 0 references () [0]
+  Live Value +Types.+i64Const: 0 references () [0]
+  Live Value +Types.+currentTime: 0 references () [0]
+  Live Value +Types.+testInstantiateTypeParameter: 0 references () [0]
   Dead Type +Types.+someRecord.+id: 0 references () [0]
-  Live Value +Types.setMatch: 0 references () [0]
-  Live Value +Types.testMarshalFields: 0 references () [1]
+  Live Value +Types.+setMatch: 0 references () [0]
+  Live Value +Types.+testMarshalFields: 0 references () [1]
   Live Value +Types.+unsafe_expr: 1 references (Types.re:118:4) [0]
-  Live Value +Types.testConvertNull: 0 references () [0]
+  Live Value +Types.+testConvertNull: 0 references () [0]
   Dead Type +Types.+record.+s: 0 references () [0]
   Dead Type +Types.+record.+i: 0 references () [0]
-  Live Value +Types.jsonStringify: 0 references () [0]
-  Live Value +Types.jsString2T: 0 references () [0]
-  Live Value +Types.jsStringT: 0 references () [0]
-  Live Value +Types.stringT: 0 references () [0]
+  Live Value +Types.+jsonStringify: 0 references () [0]
+  Live Value +Types.+jsString2T: 0 references () [0]
+  Live Value +Types.+jsStringT: 0 references () [0]
+  Live Value +Types.+stringT: 0 references () [0]
   Dead Type +Types.+opaqueVariant.+B: 0 references () [0]
   Dead Type +Types.+opaqueVariant.+A: 0 references () [0]
-  Live Value +Types.testFunctionOnOptionsAsArgument: 0 references () [0]
-  Live Value +Types.mutuallyRecursiveConverter: 0 references () [0]
-  Live Value +Types.selfRecursiveConverter: 0 references () [0]
+  Live Value +Types.+testFunctionOnOptionsAsArgument: 0 references () [0]
+  Live Value +Types.+mutuallyRecursiveConverter: 0 references () [0]
+  Live Value +Types.+selfRecursiveConverter: 0 references () [0]
   Dead Type +Types.+mutuallyRecursiveB.+a: 0 references () [0]
   Live Type +Types.+mutuallyRecursiveA.+b: 1 references (Types.re:53:34) [0]
   Live Type +Types.+selfRecursive.+self: 1 references (Types.re:46:30) [0]
-  Live Value +Types.swap: 0 references () [1]
+  Live Value +Types.+swap: 0 references () [1]
   Live Value +Types.+unsafe_expr: 1 references (Types.re:28:8) [0]
   Dead Type +Types.+typeWithVars.+B: 0 references () [0]
   Dead Type +Types.+typeWithVars.+A: 0 references () [0]
-  Live Value +Types.map: 0 references () [0]
-  Live Value +Types.someIntList: 0 references () [0]
-  Live Value +Unboxed.r2Test: 0 references () [0]
+  Live Value +Types.+map: 0 references () [0]
+  Live Value +Types.+someIntList: 0 references () [0]
+  Live Value +Unboxed.+r2Test: 0 references () [0]
   Dead Type +Unboxed.+r2.+B: 0 references () [0]
   Dead Type +Unboxed.+r1.+x: 0 references () [0]
-  Live Value +Unboxed.testV1: 0 references () [0]
+  Live Value +Unboxed.+testV1: 0 references () [0]
   Dead Type +Unboxed.+v2.+A: 0 references () [0]
   Dead Type +Unboxed.+v1.+A: 0 references () [0]
-  Live Value +Uncurried.sumLblCurried: 0 references () [0]
-  Live Value +Uncurried.sumCurried: 0 references () [0]
-  Live Value +Uncurried.sumU2: 0 references () [0]
-  Live Value +Uncurried.sumU: 0 references () [0]
-  Live Value +Uncurried.callback2U: 0 references () [0]
-  Live Value +Uncurried.callback2: 0 references () [0]
+  Live Value +Uncurried.+sumLblCurried: 0 references () [0]
+  Live Value +Uncurried.+sumCurried: 0 references () [0]
+  Live Value +Uncurried.+sumU2: 0 references () [0]
+  Live Value +Uncurried.+sumU: 0 references () [0]
+  Live Value +Uncurried.+callback2U: 0 references () [0]
+  Live Value +Uncurried.+callback2: 0 references () [0]
   Live Type +Uncurried.+authU.+loginU: 1 references (Uncurried.re:39:25) [0]
   Live Type +Uncurried.+auth.+login: 1 references (Uncurried.re:36:24) [0]
-  Live Value +Uncurried.callback: 0 references () [0]
-  Live Value +Uncurried.curried3: 0 references () [0]
-  Live Value +Uncurried.uncurried3: 0 references () [0]
-  Live Value +Uncurried.uncurried2: 0 references () [0]
-  Live Value +Uncurried.uncurried1: 0 references () [0]
-  Live Value +Uncurried.uncurried0: 0 references () [0]
-  Live Value +UseImportJsValue.useTypeImportedInOtherModule: 0 references () [0]
-  Live Value +UseImportJsValue.useGetProp: 0 references () [0]
-  Live Value +Variants.restResult3: 0 references () [0]
-  Live Value +Variants.restResult2: 0 references () [0]
-  Live Value +Variants.restResult1: 0 references () [0]
+  Live Value +Uncurried.+callback: 0 references () [0]
+  Live Value +Uncurried.+curried3: 0 references () [0]
+  Live Value +Uncurried.+uncurried3: 0 references () [0]
+  Live Value +Uncurried.+uncurried2: 0 references () [0]
+  Live Value +Uncurried.+uncurried1: 0 references () [0]
+  Live Value +Uncurried.+uncurried0: 0 references () [0]
+  Live Value +UseImportJsValue.+useTypeImportedInOtherModule: 0 references () [0]
+  Live Value +UseImportJsValue.+useGetProp: 0 references () [0]
+  Live Value +Variants.+restResult3: 0 references () [0]
+  Live Value +Variants.+restResult2: 0 references () [0]
+  Live Value +Variants.+restResult1: 0 references () [0]
   Dead Type +Variants.+result1.+Error: 0 references () [0]
   Dead Type +Variants.+result1.+Ok: 0 references () [0]
-  Live Value +Variants.polyWithOpt: 0 references () [0]
+  Live Value +Variants.+polyWithOpt: 0 references () [0]
   Dead Type +Variants.+type_.+Type: 0 references () [0]
-  Live Value +Variants.id2: 0 references () [0]
-  Live Value +Variants.id1: 0 references () [0]
-  Live Value +Variants.testConvert2to3: 0 references () [0]
-  Live Value +Variants.testConvert3: 0 references () [0]
-  Live Value +Variants.testConvert2: 0 references () [0]
-  Live Value +Variants.fortytwoBAD: 0 references () [0]
-  Live Value +Variants.fortytwoOK: 0 references () [0]
-  Live Value +Variants.testConvert: 0 references () [0]
-  Live Value +Variants.swap: 0 references () [0]
-  Live Value +Variants.onlySunday: 0 references () [0]
-  Live Value +Variants.sunday: 0 references () [0]
-  Live Value +Variants.saturday: 0 references () [0]
-  Live Value +Variants.monday: 0 references () [0]
-  Live Value +Variants.isWeekend: 0 references () [0]
-  Live Value +VariantsWithPayload.testVariant1Object: 0 references () [0]
+  Live Value +Variants.+id2: 0 references () [0]
+  Live Value +Variants.+id1: 0 references () [0]
+  Live Value +Variants.+testConvert2to3: 0 references () [0]
+  Live Value +Variants.+testConvert3: 0 references () [0]
+  Live Value +Variants.+testConvert2: 0 references () [0]
+  Live Value +Variants.+fortytwoBAD: 0 references () [0]
+  Live Value +Variants.+fortytwoOK: 0 references () [0]
+  Live Value +Variants.+testConvert: 0 references () [0]
+  Live Value +Variants.+swap: 0 references () [0]
+  Live Value +Variants.+onlySunday: 0 references () [0]
+  Live Value +Variants.+sunday: 0 references () [0]
+  Live Value +Variants.+saturday: 0 references () [0]
+  Live Value +Variants.+monday: 0 references () [0]
+  Live Value +Variants.+isWeekend: 0 references () [0]
+  Live Value +VariantsWithPayload.+testVariant1Object: 0 references () [0]
   Dead Type +VariantsWithPayload.+variant1Object.+R: 0 references () [0]
-  Live Value +VariantsWithPayload.testVariant1Int: 0 references () [0]
+  Live Value +VariantsWithPayload.+testVariant1Int: 0 references () [0]
   Dead Type +VariantsWithPayload.+variant1Int.+R: 0 references () [0]
-  Live Value +VariantsWithPayload.printVariantWithPayloads: 0 references () [0]
-  Live Value +VariantsWithPayload.testVariantWithPayloads: 0 references () [0]
+  Live Value +VariantsWithPayload.+printVariantWithPayloads: 0 references () [0]
+  Live Value +VariantsWithPayload.+testVariantWithPayloads: 0 references () [0]
   Dead Type +VariantsWithPayload.+variantWithPayloads.+E: 0 references () [0]
   Dead Type +VariantsWithPayload.+variantWithPayloads.+D: 0 references () [0]
   Dead Type +VariantsWithPayload.+variantWithPayloads.+C: 0 references () [0]
   Dead Type +VariantsWithPayload.+variantWithPayloads.+B: 0 references () [0]
   Dead Type +VariantsWithPayload.+variantWithPayloads.+A: 0 references () [0]
-  Live Value +VariantsWithPayload.testSimpleVariant: 0 references () [0]
+  Live Value +VariantsWithPayload.+testSimpleVariant: 0 references () [0]
   Dead Type +VariantsWithPayload.+simpleVariant.+C: 0 references () [0]
   Dead Type +VariantsWithPayload.+simpleVariant.+B: 0 references () [0]
   Dead Type +VariantsWithPayload.+simpleVariant.+A: 0 references () [0]
-  Live Value +VariantsWithPayload.printManyPayloads: 0 references () [0]
-  Live Value +VariantsWithPayload.testManyPayloads: 0 references () [0]
-  Live Value +VariantsWithPayload.printVariantWithPayload: 0 references () [0]
-  Live Value +VariantsWithPayload.testWithPayload: 0 references () [0]
+  Live Value +VariantsWithPayload.+printManyPayloads: 0 references () [0]
+  Live Value +VariantsWithPayload.+testManyPayloads: 0 references () [0]
+  Live Value +VariantsWithPayload.+printVariantWithPayload: 0 references () [0]
+  Live Value +VariantsWithPayload.+testWithPayload: 0 references () [0]
   Live Type +VariantsWithPayload.+payload.+y: 2 references (VariantsWithPayload.re:27:59, VariantsWithPayload.re:46:53) [0]
   Live Type +VariantsWithPayload.+payload.+x: 2 references (VariantsWithPayload.re:27:42, VariantsWithPayload.re:46:36) [0]
-  Live Value +BootloaderResource.read: 1 references (DeadTest.re:112:40) [0]
-  Dead Value +DeadTypeTest._: 0 references () [0]
-  Dead Value +DeadTypeTest._: 0 references () [0]
+  Live Value +BootloaderResource.+read: 1 references (DeadTest.re:112:40) [0]
+  Dead Value +DeadTypeTest.+_: 0 references () [0]
+  Dead Value +DeadTypeTest.+_: 0 references () [0]
   Dead Type +DeadTypeTest.+deadType.+InNeither: 0 references () [0]
   Live Type +DeadTypeTest.+deadType.+InBoth: 1 references (DeadTypeTest.re:13:8) [0]
   Dead Type +DeadTypeTest.+deadType.+OnlyInInterface: 0 references () [0]
   Live Type +DeadTypeTest.+deadType.+OnlyInImplementation: 1 references (DeadTypeTest.re:12:8) [0]
-  Dead Value +DeadTypeTest.a: 0 references () [0]
+  Dead Value +DeadTypeTest.+a: 0 references () [0]
   Dead Type +DeadTypeTest.+t.+B: 0 references () [0]
   Live Type +DeadTypeTest.+t.+A: 1 references (DeadTypeTest.re:4:8) [0]
-  Dead Value DeadValueTest.valueDead: 0 references () [0]
-  Live Value DeadValueTest.valueAlive: 1 references (DeadTest.re:77:16) [0]
-  Live Value +DynamicallyLoadedComponent.make: 4 references (DeadTest.re:112:40, DeadTest.re:119:6, DeadTest.re:157:17, DeadTest:0:-1) [0]
-  Dead Value ErrorHandler.x: 0 references () [0]
-  Live Value ErrorHandler.Make.notify: 1 references (CreateErrorHandler1.re:8:0) [0]
-  Dead Value +FirstClassModulesInterface.r: 0 references () [0]
+  Dead Value DeadValueTest.+valueDead: 0 references () [0]
+  Live Value DeadValueTest.+valueAlive: 1 references (DeadTest.re:77:16) [0]
+  Dead Value ErrorHandler.+x: 0 references () [0]
+  Live Value ErrorHandler.Make.+notify: 1 references (CreateErrorHandler1.re:8:0) [0]
+  Dead Value +FirstClassModulesInterface.+r: 0 references () [0]
   Dead Type +FirstClassModulesInterface.+record.+y: 0 references () [0]
   Dead Type +FirstClassModulesInterface.+record.+x: 0 references () [0]
-  Dead Value ImmutableArray.eq: 0 references () [0]
-  Dead Value ImmutableArray.eqU: 0 references () [0]
-  Dead Value ImmutableArray.cmp: 0 references () [0]
-  Dead Value ImmutableArray.cmpU: 0 references () [0]
-  Dead Value ImmutableArray.some2: 0 references () [0]
-  Dead Value ImmutableArray.some2U: 0 references () [0]
-  Dead Value ImmutableArray.every2: 0 references () [0]
-  Dead Value ImmutableArray.every2U: 0 references () [0]
-  Dead Value ImmutableArray.every: 0 references () [0]
-  Dead Value ImmutableArray.everyU: 0 references () [0]
-  Dead Value ImmutableArray.some: 0 references () [0]
-  Dead Value ImmutableArray.someU: 0 references () [0]
-  Dead Value ImmutableArray.reduceReverse2: 0 references () [0]
-  Dead Value ImmutableArray.reduceReverse2U: 0 references () [0]
-  Dead Value ImmutableArray.reduceReverse: 0 references () [0]
-  Dead Value ImmutableArray.reduceReverseU: 0 references () [0]
-  Dead Value ImmutableArray.reduce: 0 references () [0]
-  Dead Value ImmutableArray.reduceU: 0 references () [0]
-  Dead Value ImmutableArray.partition: 0 references () [0]
-  Dead Value ImmutableArray.partitionU: 0 references () [0]
-  Dead Value ImmutableArray.mapWithIndex: 0 references () [0]
-  Dead Value ImmutableArray.mapWithIndexU: 0 references () [0]
-  Dead Value ImmutableArray.forEachWithIndex: 0 references () [0]
-  Dead Value ImmutableArray.forEachWithIndexU: 0 references () [0]
-  Dead Value ImmutableArray.keepMap: 0 references () [0]
-  Dead Value ImmutableArray.keepMapU: 0 references () [0]
-  Dead Value ImmutableArray.keepWithIndex: 0 references () [0]
-  Dead Value ImmutableArray.keepWithIndexU: 0 references () [0]
-  Dead Value ImmutableArray.map: 0 references () [0]
-  Dead Value ImmutableArray.mapU: 0 references () [0]
-  Dead Value ImmutableArray.forEach: 0 references () [0]
-  Dead Value ImmutableArray.forEachU: 0 references () [0]
-  Dead Value ImmutableArray.copy: 0 references () [0]
-  Dead Value ImmutableArray.sliceToEnd: 0 references () [0]
-  Dead Value ImmutableArray.slice: 0 references () [0]
-  Dead Value ImmutableArray.concatMany: 0 references () [0]
-  Dead Value ImmutableArray.concat: 0 references () [0]
-  Dead Value ImmutableArray.unzip: 0 references () [0]
-  Dead Value ImmutableArray.zipBy: 0 references () [0]
-  Dead Value ImmutableArray.zipByU: 0 references () [0]
-  Dead Value ImmutableArray.zip: 0 references () [0]
-  Dead Value ImmutableArray.makeByAndShuffle: 0 references () [0]
-  Dead Value ImmutableArray.makeByAndShuffleU: 0 references () [0]
-  Dead Value ImmutableArray.makeBy: 0 references () [0]
-  Dead Value ImmutableArray.makeByU: 0 references () [0]
-  Dead Value ImmutableArray.rangeBy: 0 references () [0]
-  Dead Value ImmutableArray.range: 0 references () [0]
-  Dead Value ImmutableArray.make: 0 references () [0]
-  Dead Value ImmutableArray.makeUninitializedUnsafe: 0 references () [0]
-  Dead Value ImmutableArray.makeUninitialized: 0 references () [0]
-  Dead Value ImmutableArray.reverse: 0 references () [0]
-  Dead Value ImmutableArray.shuffle: 0 references () [0]
-  Dead Value ImmutableArray.getUndefined: 0 references () [0]
-  Dead Value ImmutableArray.getUnsafe: 0 references () [0]
-  Dead Value ImmutableArray.getExn: 0 references () [0]
-  Dead Value ImmutableArray.get: 0 references () [0]
-  Dead Value ImmutableArray.size: 0 references () [0]
-  Dead Value ImmutableArray.length: 0 references () [0]
-  Dead Value ImmutableArray.toArray: 0 references () [0]
-  Live Value ImmutableArray.fromArray: 1 references (DeadTest.re:1:15) [0]
-  Live Value ImmutableArray.Array.get: 1 references (TestImmutableArray.re:2:4) [0]
-  Live Value +ImportHookDefault.make2: 0 references () [0]
-  Live Value +ImportHookDefault.make: 0 references () [0]
+  Dead Value ImmutableArray.+eq: 0 references () [0]
+  Dead Value ImmutableArray.+eqU: 0 references () [0]
+  Dead Value ImmutableArray.+cmp: 0 references () [0]
+  Dead Value ImmutableArray.+cmpU: 0 references () [0]
+  Dead Value ImmutableArray.+some2: 0 references () [0]
+  Dead Value ImmutableArray.+some2U: 0 references () [0]
+  Dead Value ImmutableArray.+every2: 0 references () [0]
+  Dead Value ImmutableArray.+every2U: 0 references () [0]
+  Dead Value ImmutableArray.+every: 0 references () [0]
+  Dead Value ImmutableArray.+everyU: 0 references () [0]
+  Dead Value ImmutableArray.+some: 0 references () [0]
+  Dead Value ImmutableArray.+someU: 0 references () [0]
+  Dead Value ImmutableArray.+reduceReverse2: 0 references () [0]
+  Dead Value ImmutableArray.+reduceReverse2U: 0 references () [0]
+  Dead Value ImmutableArray.+reduceReverse: 0 references () [0]
+  Dead Value ImmutableArray.+reduceReverseU: 0 references () [0]
+  Dead Value ImmutableArray.+reduce: 0 references () [0]
+  Dead Value ImmutableArray.+reduceU: 0 references () [0]
+  Dead Value ImmutableArray.+partition: 0 references () [0]
+  Dead Value ImmutableArray.+partitionU: 0 references () [0]
+  Dead Value ImmutableArray.+mapWithIndex: 0 references () [0]
+  Dead Value ImmutableArray.+mapWithIndexU: 0 references () [0]
+  Dead Value ImmutableArray.+forEachWithIndex: 0 references () [0]
+  Dead Value ImmutableArray.+forEachWithIndexU: 0 references () [0]
+  Dead Value ImmutableArray.+keepMap: 0 references () [0]
+  Dead Value ImmutableArray.+keepMapU: 0 references () [0]
+  Dead Value ImmutableArray.+keepWithIndex: 0 references () [0]
+  Dead Value ImmutableArray.+keepWithIndexU: 0 references () [0]
+  Dead Value ImmutableArray.+map: 0 references () [0]
+  Dead Value ImmutableArray.+mapU: 0 references () [0]
+  Dead Value ImmutableArray.+forEach: 0 references () [0]
+  Dead Value ImmutableArray.+forEachU: 0 references () [0]
+  Dead Value ImmutableArray.+copy: 0 references () [0]
+  Dead Value ImmutableArray.+sliceToEnd: 0 references () [0]
+  Dead Value ImmutableArray.+slice: 0 references () [0]
+  Dead Value ImmutableArray.+concatMany: 0 references () [0]
+  Dead Value ImmutableArray.+concat: 0 references () [0]
+  Dead Value ImmutableArray.+unzip: 0 references () [0]
+  Dead Value ImmutableArray.+zipBy: 0 references () [0]
+  Dead Value ImmutableArray.+zipByU: 0 references () [0]
+  Dead Value ImmutableArray.+zip: 0 references () [0]
+  Dead Value ImmutableArray.+makeByAndShuffle: 0 references () [0]
+  Dead Value ImmutableArray.+makeByAndShuffleU: 0 references () [0]
+  Dead Value ImmutableArray.+makeBy: 0 references () [0]
+  Dead Value ImmutableArray.+makeByU: 0 references () [0]
+  Dead Value ImmutableArray.+rangeBy: 0 references () [0]
+  Dead Value ImmutableArray.+range: 0 references () [0]
+  Dead Value ImmutableArray.+make: 0 references () [0]
+  Dead Value ImmutableArray.+makeUninitializedUnsafe: 0 references () [0]
+  Dead Value ImmutableArray.+makeUninitialized: 0 references () [0]
+  Dead Value ImmutableArray.+reverse: 0 references () [0]
+  Dead Value ImmutableArray.+shuffle: 0 references () [0]
+  Dead Value ImmutableArray.+getUndefined: 0 references () [0]
+  Dead Value ImmutableArray.+getUnsafe: 0 references () [0]
+  Dead Value ImmutableArray.+getExn: 0 references () [0]
+  Dead Value ImmutableArray.+get: 0 references () [0]
+  Dead Value ImmutableArray.+size: 0 references () [0]
+  Dead Value ImmutableArray.+length: 0 references () [0]
+  Dead Value ImmutableArray.+toArray: 0 references () [0]
+  Live Value ImmutableArray.+fromArray: 1 references (DeadTest.re:1:15) [0]
+  Live Value ImmutableArray.Array.+get: 1 references (TestImmutableArray.re:2:4) [0]
+  Live Value +ImportHookDefault.+make2: 0 references () [0]
+  Live Value +ImportHookDefault.+make: 0 references () [0]
   Dead Type +ImportHookDefault.+person.+age: 0 references () [0]
   Dead Type +ImportHookDefault.+person.+name: 0 references () [0]
-  Live Value +ImportHooks.foo: 0 references () [0]
-  Live Value +ImportHooks.make: 0 references () [0]
+  Live Value +ImportHooks.+foo: 0 references () [0]
+  Live Value +ImportHooks.+make: 0 references () [0]
   Dead Type +ImportHooks.+person.+age: 0 references () [0]
   Dead Type +ImportHooks.+person.+name: 0 references () [0]
-  Live Value +ImportJsValue.default: 0 references () [0]
-  Live Value +ImportJsValue.polymorphic: 0 references () [0]
-  Live Value +ImportJsValue.convertVariant: 0 references () [0]
+  Live Value +ImportJsValue.+default: 0 references () [0]
+  Live Value +ImportJsValue.+polymorphic: 0 references () [0]
+  Live Value +ImportJsValue.+convertVariant: 0 references () [0]
   Dead Type +ImportJsValue.+variant.+S: 0 references () [0]
   Dead Type +ImportJsValue.+variant.+I: 0 references () [0]
-  Live Value +ImportJsValue.returnedFromHigherOrder: 0 references () [0]
-  Live Value +ImportJsValue.higherOrder: 1 references (ImportJsValue.re:62:4) [0]
-  Live Value +ImportJsValue.useColor: 0 references () [0]
-  Live Value +ImportJsValue.useGetAbs: 0 references () [0]
-  Live Value +ImportJsValue.useGetProp: 0 references () [0]
-  Live Value +ImportJsValue.AbsoluteValue.getAbs: 1 references (ImportJsValue.re:48:4) [0]
-  Live Value +ImportJsValue.AbsoluteValue.getProp: 2 references (ImportJsValue.re:45:4, UseImportJsValue.re:2:4) [0]
+  Live Value +ImportJsValue.+returnedFromHigherOrder: 0 references () [0]
+  Live Value +ImportJsValue.+higherOrder: 1 references (ImportJsValue.re:62:4) [0]
+  Live Value +ImportJsValue.+useColor: 0 references () [0]
+  Live Value +ImportJsValue.+useGetAbs: 0 references () [0]
+  Live Value +ImportJsValue.+useGetProp: 0 references () [0]
+  Live Value +ImportJsValue.AbsoluteValue.+getAbs: 1 references (ImportJsValue.re:48:4) [1]
   Live Value +ImportJsValue.AbsoluteValue.+getAbs: 1 references (ImportJsValue.re:38:6) [0]
-  Live Value +ImportJsValue.areaValue: 0 references () [0]
-  Live Value +ImportJsValue.roundedNumber: 0 references () [0]
-  Live Value +ImportJsValue.returnMixedArray: 0 references () [0]
-  Live Value +ImportJsValue.area: 1 references (ImportJsValue.re:28:4) [0]
+  Live Value +ImportJsValue.AbsoluteValue.+getProp: 2 references (ImportJsValue.re:45:4, UseImportJsValue.re:2:4) [0]
+  Live Value +ImportJsValue.+areaValue: 0 references () [0]
+  Live Value +ImportJsValue.+roundedNumber: 0 references () [0]
+  Live Value +ImportJsValue.+returnMixedArray: 0 references () [0]
+  Live Value +ImportJsValue.+area: 1 references (ImportJsValue.re:28:4) [0]
   Dead Type +ImportJsValue.+point.+y: 0 references () [0]
   Dead Type +ImportJsValue.+point.+x: 0 references () [0]
-  Live Value +ImportJsValue.round: 1 references (ImportJsValue.re:25:4) [0]
-  Live Value +ImportMyBanner.make: 1 references (ReasonComponent.re:18:4) [0]
-  Live Value +ImportMyBanner.make: 1 references (ImportMyBanner.re:19:4) [0]
+  Live Value +ImportJsValue.+round: 1 references (ImportJsValue.re:25:4) [0]
+  Live Value +ImportMyBanner.+make: 1 references (ReasonComponent.re:18:4) [0]
+  Live Value +ImportMyBanner.+make: 1 references (ImportMyBanner.re:19:4) [0]
   Dead Type +ImportMyBanner.+message.+text: 0 references () [0]
-  Live Value +JSResource.jSResource: 2 references (DeadTest.re:112:40, DeadTest.re:119:6) [0]
-  Live Value +NestedModulesInSignature.Universe.theAnswer: 1 references (NestedModulesInSignature.rei:2:2) [0]
-  Dead Value +DeadValueTest.valueOnlyInImplementation: 0 references () [0]
-  Dead Value +DeadValueTest.valueDead: 0 references () [0]
-  Live Value +DeadValueTest.valueAlive: 1 references (DeadValueTest.rei:1:0) [0]
-  Dead Value +ErrorHandler.x: 0 references () [0]
-  Live Value +ErrorHandler.Make.notify: 1 references (ErrorHandler.rei:5:32) [0]
-  Dead Value +ImmutableArray.eq: 0 references () [0]
-  Dead Value +ImmutableArray.eqU: 0 references () [0]
-  Dead Value +ImmutableArray.cmp: 0 references () [0]
-  Dead Value +ImmutableArray.cmpU: 0 references () [0]
-  Dead Value +ImmutableArray.some2: 0 references () [0]
-  Dead Value +ImmutableArray.some2U: 0 references () [0]
-  Dead Value +ImmutableArray.every2: 0 references () [0]
-  Dead Value +ImmutableArray.every2U: 0 references () [0]
-  Dead Value +ImmutableArray.every: 0 references () [0]
-  Dead Value +ImmutableArray.everyU: 0 references () [0]
-  Dead Value +ImmutableArray.some: 0 references () [0]
-  Dead Value +ImmutableArray.someU: 0 references () [0]
-  Dead Value +ImmutableArray.reduceReverse2: 0 references () [0]
-  Dead Value +ImmutableArray.reduceReverse2U: 0 references () [0]
-  Dead Value +ImmutableArray.reduceReverse: 0 references () [0]
-  Dead Value +ImmutableArray.reduceReverseU: 0 references () [0]
-  Dead Value +ImmutableArray.reduce: 0 references () [0]
-  Dead Value +ImmutableArray.reduceU: 0 references () [0]
-  Dead Value +ImmutableArray.partition: 0 references () [0]
-  Dead Value +ImmutableArray.partitionU: 0 references () [0]
-  Dead Value +ImmutableArray.mapWithIndex: 0 references () [0]
-  Dead Value +ImmutableArray.mapWithIndexU: 0 references () [0]
-  Dead Value +ImmutableArray.forEachWithIndex: 0 references () [0]
-  Dead Value +ImmutableArray.forEachWithIndexU: 0 references () [0]
-  Dead Value +ImmutableArray.keepMap: 0 references () [0]
-  Dead Value +ImmutableArray.keepMapU: 0 references () [0]
-  Dead Value +ImmutableArray.keepWithIndex: 0 references () [0]
-  Dead Value +ImmutableArray.keepWithIndexU: 0 references () [0]
-  Dead Value +ImmutableArray.map: 0 references () [0]
-  Dead Value +ImmutableArray.mapU: 0 references () [0]
-  Dead Value +ImmutableArray.forEach: 0 references () [0]
-  Dead Value +ImmutableArray.forEachU: 0 references () [0]
-  Dead Value +ImmutableArray.copy: 0 references () [0]
-  Dead Value +ImmutableArray.sliceToEnd: 0 references () [0]
-  Dead Value +ImmutableArray.slice: 0 references () [0]
-  Dead Value +ImmutableArray.concatMany: 0 references () [0]
-  Dead Value +ImmutableArray.concat: 0 references () [0]
-  Dead Value +ImmutableArray.unzip: 0 references () [0]
-  Dead Value +ImmutableArray.zipBy: 0 references () [0]
-  Dead Value +ImmutableArray.zipByU: 0 references () [0]
-  Dead Value +ImmutableArray.zip: 0 references () [0]
-  Dead Value +ImmutableArray.makeByAndShuffle: 0 references () [0]
-  Dead Value +ImmutableArray.makeByAndShuffleU: 0 references () [0]
-  Dead Value +ImmutableArray.makeBy: 0 references () [0]
-  Dead Value +ImmutableArray.makeByU: 0 references () [0]
-  Dead Value +ImmutableArray.rangeBy: 0 references () [0]
-  Dead Value +ImmutableArray.range: 0 references () [0]
-  Dead Value +ImmutableArray.make: 0 references () [0]
-  Dead Value +ImmutableArray.makeUninitializedUnsafe: 0 references () [0]
-  Dead Value +ImmutableArray.makeUninitialized: 0 references () [0]
-  Dead Value +ImmutableArray.reverse: 0 references () [0]
-  Dead Value +ImmutableArray.shuffle: 0 references () [0]
-  Dead Value +ImmutableArray.getUndefined: 0 references () [0]
-  Dead Value +ImmutableArray.getUnsafe: 0 references () [0]
-  Dead Value +ImmutableArray.getExn: 0 references () [0]
-  Live Value +ImmutableArray.get: 1 references (ImmutableArray.rei:5:15) [0]
-  Dead Value +ImmutableArray.size: 0 references () [0]
-  Dead Value +ImmutableArray.length: 0 references () [0]
-  Dead Value +ImmutableArray.toArray: 0 references () [0]
-  Live Value +ImmutableArray.fromArray: 1 references (ImmutableArray.rei:7:0) [0]
-  Dead Value +ImmutableArray.toT2: 0 references () [0]
-  Dead Value +ImmutableArray.toTp: 0 references () [0]
-  Live Value +ImmutableArray.toT: 1 references (ImmutableArray.re:14:6) [0]
-  Dead Value +ImmutableArray.fromTT: 0 references () [0]
-  Dead Value +ImmutableArray.fromTp: 0 references () [0]
-  Live Value +ImmutableArray.fromT: 1 references (ImmutableArray.re:24:6) [0]
+  Live Value +JSResource.+jSResource: 2 references (DeadTest.re:112:40, DeadTest.re:119:6) [0]
+  Live Value +NestedModulesInSignature.Universe.+theAnswer: 1 references (NestedModulesInSignature.rei:2:2) [0]
+  Dead Value +DeadValueTest.+valueOnlyInImplementation: 0 references () [0]
+  Dead Value +DeadValueTest.+valueDead: 0 references () [0]
+  Live Value +DeadValueTest.+valueAlive: 1 references (DeadValueTest.rei:1:0) [0]
+  Dead Value +ErrorHandler.+x: 0 references () [0]
+  Live Value +ErrorHandler.Make.+notify: 1 references (ErrorHandler.rei:5:32) [0]
+  Dead Value +ImmutableArray.+eq: 0 references () [0]
+  Dead Value +ImmutableArray.+eqU: 0 references () [0]
+  Dead Value +ImmutableArray.+cmp: 0 references () [0]
+  Dead Value +ImmutableArray.+cmpU: 0 references () [0]
+  Dead Value +ImmutableArray.+some2: 0 references () [0]
+  Dead Value +ImmutableArray.+some2U: 0 references () [0]
+  Dead Value +ImmutableArray.+every2: 0 references () [0]
+  Dead Value +ImmutableArray.+every2U: 0 references () [0]
+  Dead Value +ImmutableArray.+every: 0 references () [0]
+  Dead Value +ImmutableArray.+everyU: 0 references () [0]
+  Dead Value +ImmutableArray.+some: 0 references () [0]
+  Dead Value +ImmutableArray.+someU: 0 references () [0]
+  Dead Value +ImmutableArray.+reduceReverse2: 0 references () [0]
+  Dead Value +ImmutableArray.+reduceReverse2U: 0 references () [0]
+  Dead Value +ImmutableArray.+reduceReverse: 0 references () [0]
+  Dead Value +ImmutableArray.+reduceReverseU: 0 references () [0]
+  Dead Value +ImmutableArray.+reduce: 0 references () [0]
+  Dead Value +ImmutableArray.+reduceU: 0 references () [0]
+  Dead Value +ImmutableArray.+partition: 0 references () [0]
+  Dead Value +ImmutableArray.+partitionU: 0 references () [0]
+  Dead Value +ImmutableArray.+mapWithIndex: 0 references () [0]
+  Dead Value +ImmutableArray.+mapWithIndexU: 0 references () [0]
+  Dead Value +ImmutableArray.+forEachWithIndex: 0 references () [0]
+  Dead Value +ImmutableArray.+forEachWithIndexU: 0 references () [0]
+  Dead Value +ImmutableArray.+keepMap: 0 references () [0]
+  Dead Value +ImmutableArray.+keepMapU: 0 references () [0]
+  Dead Value +ImmutableArray.+keepWithIndex: 0 references () [0]
+  Dead Value +ImmutableArray.+keepWithIndexU: 0 references () [0]
+  Dead Value +ImmutableArray.+map: 0 references () [0]
+  Dead Value +ImmutableArray.+mapU: 0 references () [0]
+  Dead Value +ImmutableArray.+forEach: 0 references () [0]
+  Dead Value +ImmutableArray.+forEachU: 0 references () [0]
+  Dead Value +ImmutableArray.+copy: 0 references () [0]
+  Dead Value +ImmutableArray.+sliceToEnd: 0 references () [0]
+  Dead Value +ImmutableArray.+slice: 0 references () [0]
+  Dead Value +ImmutableArray.+concatMany: 0 references () [0]
+  Dead Value +ImmutableArray.+concat: 0 references () [0]
+  Dead Value +ImmutableArray.+unzip: 0 references () [0]
+  Dead Value +ImmutableArray.+zipBy: 0 references () [0]
+  Dead Value +ImmutableArray.+zipByU: 0 references () [0]
+  Dead Value +ImmutableArray.+zip: 0 references () [0]
+  Dead Value +ImmutableArray.+makeByAndShuffle: 0 references () [0]
+  Dead Value +ImmutableArray.+makeByAndShuffleU: 0 references () [0]
+  Dead Value +ImmutableArray.+makeBy: 0 references () [0]
+  Dead Value +ImmutableArray.+makeByU: 0 references () [0]
+  Dead Value +ImmutableArray.+rangeBy: 0 references () [0]
+  Dead Value +ImmutableArray.+range: 0 references () [0]
+  Dead Value +ImmutableArray.+make: 0 references () [0]
+  Dead Value +ImmutableArray.+makeUninitializedUnsafe: 0 references () [0]
+  Dead Value +ImmutableArray.+makeUninitialized: 0 references () [0]
+  Dead Value +ImmutableArray.+reverse: 0 references () [0]
+  Dead Value +ImmutableArray.+shuffle: 0 references () [0]
+  Dead Value +ImmutableArray.+getUndefined: 0 references () [0]
+  Dead Value +ImmutableArray.+getUnsafe: 0 references () [0]
+  Dead Value +ImmutableArray.+getExn: 0 references () [0]
+  Live Value +ImmutableArray.+get: 1 references (ImmutableArray.rei:5:15) [0]
+  Dead Value +ImmutableArray.+size: 0 references () [0]
+  Dead Value +ImmutableArray.+length: 0 references () [0]
+  Dead Value +ImmutableArray.+toArray: 0 references () [0]
+  Live Value +ImmutableArray.+fromArray: 1 references (ImmutableArray.rei:7:0) [0]
+  Dead Value +ImmutableArray.+toT2: 0 references () [0]
+  Dead Value +ImmutableArray.+toTp: 0 references () [0]
+  Live Value +ImmutableArray.+toT: 1 references (ImmutableArray.re:14:6) [0]
+  Dead Value +ImmutableArray.+fromTT: 0 references () [0]
+  Dead Value +ImmutableArray.+fromTp: 0 references () [0]
+  Live Value +ImmutableArray.+fromT: 1 references (ImmutableArray.re:24:6) [0]
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/AutoAnnotate.re 2:5-10
@@ -2429,27 +2423,27 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/BucklescriptAnnotations.re 19:1-53
-  foo is never used
+  +foo is never used
   <-- line 19
-  [@dead "foo"] let foo = (x: someMethods) => x##threeargs(3, "a", 4);
+  [@dead "+foo"] let foo = (x: someMethods) => x##threeargs(3, "a", 4);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/BucklescriptAnnotations.re 21:1-24:1
-  bar is never used
+  +bar is never used
   <-- line 21
-  [@dead "bar"] let bar = (x: someMethods) => {
+  [@dead "+bar"] let bar = (x: someMethods) => {
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 3, characters 4-93
-  QQ.thisSpansSeveralLines is never used
+  QQ.+thisSpansSeveralLines is never used
   <-- line 3
-            x + y : int -> int -> int) [@@dead "QQ.thisSpansSeveralLines"] 
+            x + y : int -> int -> int) [@@dead "QQ.+thisSpansSeveralLines"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 9, characters 2-40
-  AA.thisIsInInterface is never used
+  AA.+thisIsInInterface is never used
   <-- line 9
-      int -> int [@@dead "AA.thisIsInInterface"] 
+      int -> int [@@dead "AA.+thisIsInInterface"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 12, characters 2-29
@@ -2459,9 +2453,9 @@ File References
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 15, characters 0-25
-  thisHasSemicolons is never used
+  +thisHasSemicolons is never used
   <-- line 15
-  let thisHasSemicolons = 3 [@@dead "thisHasSemicolons"] ;;
+  let thisHasSemicolons = 3 [@@dead "+thisHasSemicolons"] ;;
 
   Warning Dead Type
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 17, characters 18-25
@@ -2477,21 +2471,21 @@ File References
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 26, characters 6-26
-  Bs_version.version is never used
+  Bs_version.+version is never used
   <-- line 26
-    sig val version : string [@@dead "Bs_version.version"]  val header : string val package_name : string end 
+    sig val version : string [@@dead "Bs_version.+version"]  val header : string val package_name : string end 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 26, characters 27-46
-  Bs_version.header is never used
+  Bs_version.+header is never used
   <-- line 26
-    sig val version : string [@@dead "Bs_version.version"]  val header : string [@@dead "Bs_version.header"]  val package_name : string end 
+    sig val version : string [@@dead "Bs_version.+version"]  val header : string [@@dead "Bs_version.+header"]  val package_name : string end 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 26, characters 47-72
-  Bs_version.package_name is never used
+  Bs_version.+package_name is never used
   <-- line 26
-    sig val version : string [@@dead "Bs_version.version"]  val header : string [@@dead "Bs_version.header"]  val package_name : string [@@dead "Bs_version.package_name"]  end 
+    sig val version : string [@@dead "Bs_version.+version"]  val header : string [@@dead "Bs_version.+header"]  val package_name : string [@@dead "Bs_version.+package_name"]  end 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 29, characters 4-31
@@ -2531,63 +2525,63 @@ File References
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 45, characters 0-305
-  map_split_opt is never used
+  +map_split_opt is never used
   <-- line 45
-      (match d with Some d -> d::ds | None -> ds) [@@dead "map_split_opt"] 
+      (match d with Some d -> d::ds | None -> ds) [@@dead "+map_split_opt"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 56, characters 0-40
-  inline_threshold is never used
+  +inline_threshold is never used
   <-- line 56
-  let inline_threshold = Some (10. /. 8.); [@@dead "inline_threshold"] 
+  let inline_threshold = Some (10. /. 8.); [@@dead "+inline_threshold"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 59, characters 2-15
-  Scope.dead1 is never used
+  Scope.+dead1 is never used
   <-- line 59
-    let dead1 = 1 [@@dead "Scope.dead1"] 
+    let dead1 = 1 [@@dead "Scope.+dead1"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 62, characters 4-22
-  Scope.Inner1.deadInner1 is never used
+  Scope.Inner1.+deadInner1 is never used
   <-- line 62
-      let deadInner1 = 0 [@@dead "Scope.Inner1.deadInner1"] 
+      let deadInner1 = 0 [@@dead "Scope.Inner1.+deadInner1"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 69, characters 2-15
-  Scope.dead2 is never used
+  Scope.+dead2 is never used
   <-- line 69
-    let dead2 = 2 [@@dead "Scope.dead2"] 
+    let dead2 = 2 [@@dead "Scope.+dead2"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 80, characters 0-13
-  dead4 is never used
+  +dead4 is never used
   <-- line 80
-  let dead4 = 4 [@@dead "dead4"] 
+  let dead4 = 4 [@@dead "+dead4"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 85, characters 0-13
-  dead5 is never used
+  +dead5 is never used
   <-- line 85
-  let dead5 = 5 [@@dead "dead5"] 
+  let dead5 = 5 [@@dead "+dead5"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 90, characters 0-37
-  dead7 is never used
+  +dead7 is never used
   <-- line 90
-  [@@ocaml.warning "-30"] [@@dead "dead7"] 
+  [@@ocaml.warning "-30"] [@@dead "+dead7"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 94, characters 2-16
-  WithSignature.dead8 is never used
+  WithSignature.+dead8 is never used
   <-- line 94
-    val dead8: int [@@dead "WithSignature.dead8"] 
+    val dead8: int [@@dead "WithSignature.+dead8"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 99, characters 2-17
-  WithSignature.dead10 is never used
+  WithSignature.+dead10 is never used
   <-- line 99
-    val dead10: int [@@dead "WithSignature.dead10"] 
+    val dead10: int [@@dead "WithSignature.+dead10"] 
 
   Warning Dead Value
   File "/Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadMl.ml", line 106, characters 2-15
@@ -2609,9 +2603,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadRT.re 5:1-9:3
-  emitModuleAccessPath is never used
+  +emitModuleAccessPath is never used
   <-- line 5
-  [@dead "emitModuleAccessPath"] let rec emitModuleAccessPath = moduleAccessPath =>
+  [@dead "+emitModuleAccessPath"] let rec emitModuleAccessPath = moduleAccessPath =>
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadRT.rei 3:5-10
@@ -2621,9 +2615,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 2:1-17
-  fortytwo is never used
+  +fortytwo is never used
   <-- line 2
-  [@dead "fortytwo"] let fortytwo = 42;
+  [@dead "+fortytwo"] let fortytwo = 42;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 31:3-34
@@ -2633,9 +2627,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 63:3-12
-  MM.y is never used
+  MM.+y is never used
   <-- line 63
-    [@dead "MM.y"] let y: int;
+    [@dead "MM.+y"] let y: int;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 69:3-35
@@ -2645,63 +2639,63 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 79:1-37
-  unusedRec is never used
+  +unusedRec is never used
   <-- line 79
-  [@dead "unusedRec"] let rec unusedRec = () => unusedRec();
+  [@dead "+unusedRec"] let rec unusedRec = () => unusedRec();
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 81:1-84:1
-  split_map is never used
+  +split_map is never used
   <-- line 81
-  [@dead "split_map"] let rec split_map = l => {
+  [@dead "+split_map"] let rec split_map = l => {
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 86:1-27
-  rec1 is never used
+  +rec1 is never used
   <-- line 86
-  [@dead "rec1"] let rec rec1 = () => rec2()
+  [@dead "+rec1"] let rec rec1 = () => rec2()
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 87:1-23
-  rec2 is never used
+  +rec2 is never used
   <-- line 87
-  [@dead "rec2"] and rec2 = () => rec1();
+  [@dead "+rec2"] and rec2 = () => rec1();
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 89:1-92:1
-  recWithCallback is never used
+  +recWithCallback is never used
   <-- line 89
-  [@dead "recWithCallback"] let rec recWithCallback = () => {
+  [@dead "+recWithCallback"] let rec recWithCallback = () => {
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 94:1-97:1
-  foo is never used
+  +foo is never used
   <-- line 94
-  [@dead "foo"] let rec foo = () => {
+  [@dead "+foo"] let rec foo = () => {
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 98:1-21
-  bar is never used
+  +bar is never used
   <-- line 98
-  [@dead "bar"] and bar = () => foo();
+  [@dead "+bar"] and bar = () => foo();
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 100:1-71
-  withDefaultValue is never used
+  +withDefaultValue is never used
   <-- line 100
-  [@dead "withDefaultValue"] let withDefaultValue = (~paramWithDefault=3, y) => paramWithDefault + y;
+  [@dead "+withDefaultValue"] let withDefaultValue = (~paramWithDefault=3, y) => paramWithDefault + y;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 102:1-74
-  unsafe_string1 is never used
+  +unsafe_string1 is never used
   <-- line 102
-  [@dead "unsafe_string1"] external unsafe_string1: (bytes, int, int) => Digest.t = "caml_md5_string";
+  [@dead "+unsafe_string1"] external unsafe_string1: (bytes, int, int) => Digest.t = "caml_md5_string";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 105:3-76
-  Ext_buffer.unsafe_string2 is never used
+  Ext_buffer.+unsafe_string2 is never used
   <-- line 105
-    [@dead "Ext_buffer.unsafe_string2"] external unsafe_string2: (bytes, int, int) => Digest.t = "caml_md5_string";
+    [@dead "Ext_buffer.+unsafe_string2"] external unsafe_string2: (bytes, int, int) => Digest.t = "caml_md5_string";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 107:3-76
@@ -2711,71 +2705,77 @@ File References
 
   Warning Dead Value With Side Effects
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 119:3-120:58
-  LazyDynamicallyLoadedComponent2.reasonResource is never used and could have side effects
+  LazyDynamicallyLoadedComponent2.+reasonResource is never used and could have side effects
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 121:3-54
-  LazyDynamicallyLoadedComponent2.makeProps is never used
+  LazyDynamicallyLoadedComponent2.+makeProps is never used
   <-- line 121
-    [@dead "LazyDynamicallyLoadedComponent2.makeProps"] let makeProps = DynamicallyLoadedComponent.makeProps;
+    [@dead "LazyDynamicallyLoadedComponent2.+makeProps"] let makeProps = DynamicallyLoadedComponent.makeProps;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 122:3-129:5
-  LazyDynamicallyLoadedComponent2.make is never used
+  LazyDynamicallyLoadedComponent2.+make is never used
   <-- line 122
-    [@dead "LazyDynamicallyLoadedComponent2.make"] let make = props =>
+    [@dead "LazyDynamicallyLoadedComponent2.+make"] let make = props =>
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 134:1-62
-  cmp2 is never used
+  +cmp2 is never used
   <-- line 134
-  [@dead "cmp2"] let cmp2 = () => <LazyDynamicallyLoadedComponent2 s="hello" />;
+  [@dead "+cmp2"] let cmp2 = () => <LazyDynamicallyLoadedComponent2 s="hello" />;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 150:1-155:1
-  zzz is never used
+  +zzz is never used
   <-- line 150
-  [@dead "zzz"] let zzz = {
+  [@dead "+zzz"] let zzz = {
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 159:1-15
-  second is never used
+  +second is never used
   <-- line 159
-  [@dead "second"] let second = 1L;
+  [@dead "+second"] let second = 1L;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 160:1-35
-  minute is never used
+  +minute is never used
   <-- line 160
-  [@dead "minute"] let minute = Int64.mul(60L, second);
+  [@dead "+minute"] let minute = Int64.mul(60L, second);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 162:1-21
-  deadRef is never used
+  +deadRef is never used
   <-- line 162
-  [@dead "deadRef"] let deadRef = ref(12);
+  [@dead "+deadRef"] let deadRef = ref(12);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 164:1-37
-  makeSwitch is never used
+  +makeSwitch is never used
   <-- line 164
-  [@dead "makeSwitch"] let makeSwitch = ComponentSwitch.make;
+  [@dead "+makeSwitch"] let makeSwitch = ComponentSwitch.make;
+
+  Warning Dead Value
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 166:1-167:31
+  +make is never used
+  <-- line 167
+  [@dead "+make"] [@react.component]
 
   Warning Dead Value With Side Effects
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 171:1-40
-  theSideEffectIsLogging is never used and could have side effects
+  +theSideEffectIsLogging is never used and could have side effects
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 173:1-54
-  stringLengthNoSideEffects is never used
+  +stringLengthNoSideEffects is never used
   <-- line 173
-  [@dead "stringLengthNoSideEffects"] let stringLengthNoSideEffects = String.length("sdkdl");
+  [@dead "+stringLengthNoSideEffects"] let stringLengthNoSideEffects = String.length("sdkdl");
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTestWithInterface.re 1:21-30
-  Ext_buffer.x is never used
+  Ext_buffer.+x is never used
   <-- line 1
-  module Ext_buffer: {[@dead "Ext_buffer.x"] let x: int;} = {
+  module Ext_buffer: {[@dead "Ext_buffer.+x"] let x: int;} = {
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTestWithInterface.re 2:3-12
@@ -2791,9 +2791,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.re 4:1-9
-  a is never used
+  +a is never used
   <-- line 4
-  [@dead "a"] let a = A;
+  [@dead "+a"] let a = A;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.re 8:5-19
@@ -2821,9 +2821,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 4:1-8
-  a is never used
+  +a is never used
   <-- line 4
-  [@dead "a"] let a: t;
+  [@dead "+a"] let a: t;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 7:5-24
@@ -2839,21 +2839,21 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadValueTest.re 2:1-17
-  valueDead is never used
+  +valueDead is never used
   <-- line 2
-  [@dead "valueDead"] let valueDead = 2;
+  [@dead "+valueDead"] let valueDead = 2;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadValueTest.re 4:1-33
-  valueOnlyInImplementation is never used
+  +valueOnlyInImplementation is never used
   <-- line 4
-  [@dead "valueOnlyInImplementation"] let valueOnlyInImplementation = 3;
+  [@dead "+valueOnlyInImplementation"] let valueOnlyInImplementation = 3;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadValueTest.rei 2:1-18
-  valueDead is never used
+  +valueDead is never used
   <-- line 2
-  [@dead "valueDead"] let valueDead: int;
+  [@dead "+valueDead"] let valueDead: int;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Docstrings.re 62:5
@@ -2863,15 +2863,15 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ErrorHandler.re 11:1-12:10
-  x is never used
+  +x is never used
   <-- line 12
-  [@dead "x"] [@genType]
+  [@dead "+x"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ErrorHandler.rei 7:1-10
-  x is never used
+  +x is never used
   <-- line 7
-  [@dead "x"] let x: int;
+  [@dead "+x"] let x: int;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.re 2:3-8
@@ -2887,9 +2887,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.re 6:1-26
-  r is never used
+  +r is never used
   <-- line 6
-  [@dead "r"] let r = {x: 3, y: "hello"};
+  [@dead "+r"] let r = {x: 3, y: "hello"};
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.rei 3:3-8
@@ -2905,21 +2905,21 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.rei 7:1-13
-  r is never used
+  +r is never used
   <-- line 7
-  [@dead "r"] let r: record;
+  [@dead "+r"] let r: record;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 3:1-33:1
-  make is never used
+  +make is never used
   <-- line 4
-  [@dead "make"] [@react.component]
+  [@dead "+make"] [@react.component]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 38:1-43:1
-  anotherComponent is never used
+  +anotherComponent is never used
   <-- line 40
-  [@dead "anotherComponent"] [@genType]
+  [@dead "+anotherComponent"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 46:3-49:64
@@ -2953,33 +2953,33 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 85:1-90:1
-  componentWithRenamedArgs is never used
+  +componentWithRenamedArgs is never used
   <-- line 87
-  [@dead "componentWithRenamedArgs"] [@genType]
+  [@dead "+componentWithRenamedArgs"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 92:1-102:1
-  makeWithRef is never used
+  +makeWithRef is never used
   <-- line 94
-  [@dead "makeWithRef"] [@genType]
+  [@dead "+makeWithRef"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 109:1-114:3
-  input is never used
+  +input is never used
   <-- line 111
-  [@dead "input"] [@genType]
+  [@dead "+input"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 128:1-130:65
-  polymorphicComponent is never used
+  +polymorphicComponent is never used
   <-- line 130
-  [@dead "polymorphicComponent"] [@genType]
+  [@dead "+polymorphicComponent"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 132:1-134:65
-  functionReturningReactElement is never used
+  +functionReturningReactElement is never used
   <-- line 134
-  [@dead "functionReturningReactElement"] [@genType]
+  [@dead "+functionReturningReactElement"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 137:3-151:3
@@ -2989,735 +2989,735 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Hooks.re 154:1-161:1
-  aComponentWithChildren is never used
+  +aComponentWithChildren is never used
   <-- line 156
-  [@dead "aComponentWithChildren"] [@genType]
+  [@dead "+aComponentWithChildren"] [@genType]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 6:3-63
-  fromTp is never used
+  +fromTp is never used
   <-- line 6
-    [@dead "fromTp"] external fromTp: t(('a, 'b)) => array(('a, 'b)) = "%identity";
+    [@dead "+fromTp"] external fromTp: t(('a, 'b)) => array(('a, 'b)) = "%identity";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 7:3-61
-  fromTT is never used
+  +fromTT is never used
   <-- line 7
-    [@dead "fromTT"] external fromTT: t(t('a)) => array(array('a)) = "%identity";
+    [@dead "+fromTT"] external fromTT: t(t('a)) => array(array('a)) = "%identity";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 9:3-61
-  toTp is never used
+  +toTp is never used
   <-- line 9
-    [@dead "toTp"] external toTp: array(('a, 'b)) => t(('a, 'b)) = "%identity";
+    [@dead "+toTp"] external toTp: array(('a, 'b)) => t(('a, 'b)) = "%identity";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 10:3-59
-  toT2 is never used
+  +toT2 is never used
   <-- line 10
-    [@dead "toT2"] external toT2: array2('a) => (t('a), t('a)) = "%identity";
+    [@dead "+toT2"] external toT2: array2('a) => (t('a), t('a)) = "%identity";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 16:3-41
-  toArray is never used
+  +toArray is never used
   <-- line 16
-    [@dead "toArray"] let toArray = a => Array.copy(a->fromT);
+    [@dead "+toArray"] let toArray = a => Array.copy(a->fromT);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 20:3-42
-  length is never used
+  +length is never used
   <-- line 20
-    [@dead "length"] let length = a => Array.length(a->fromT);
+    [@dead "+length"] let length = a => Array.length(a->fromT);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 22:3-38
-  size is never used
+  +size is never used
   <-- line 22
-    [@dead "size"] let size = a => Array.size(a->fromT);
+    [@dead "+size"] let size = a => Array.size(a->fromT);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 26:3-50
-  getExn is never used
+  +getExn is never used
   <-- line 26
-    [@dead "getExn"] let getExn = (a, x) => Array.getExn(a->fromT, x);
+    [@dead "+getExn"] let getExn = (a, x) => Array.getExn(a->fromT, x);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 28:3-56
-  getUnsafe is never used
+  +getUnsafe is never used
   <-- line 28
-    [@dead "getUnsafe"] let getUnsafe = (a, x) => Array.getUnsafe(a->fromT, x);
+    [@dead "+getUnsafe"] let getUnsafe = (a, x) => Array.getUnsafe(a->fromT, x);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 30:3-62
-  getUndefined is never used
+  +getUndefined is never used
   <-- line 30
-    [@dead "getUndefined"] let getUndefined = (a, x) => Array.getUndefined(a->fromT, x);
+    [@dead "+getUndefined"] let getUndefined = (a, x) => Array.getUndefined(a->fromT, x);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 32:3-49
-  shuffle is never used
+  +shuffle is never used
   <-- line 32
-    [@dead "shuffle"] let shuffle = x => Array.shuffle(x->fromT)->toT;
+    [@dead "+shuffle"] let shuffle = x => Array.shuffle(x->fromT)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 34:3-49
-  reverse is never used
+  +reverse is never used
   <-- line 34
-    [@dead "reverse"] let reverse = x => Array.reverse(x->fromT)->toT;
+    [@dead "+reverse"] let reverse = x => Array.reverse(x->fromT)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 36:3-62
-  makeUninitialized is never used
+  +makeUninitialized is never used
   <-- line 36
-    [@dead "makeUninitialized"] let makeUninitialized = x => Array.makeUninitialized(x)->toT;
+    [@dead "+makeUninitialized"] let makeUninitialized = x => Array.makeUninitialized(x)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 38:3-74
-  makeUninitializedUnsafe is never used
+  +makeUninitializedUnsafe is never used
   <-- line 38
-    [@dead "makeUninitializedUnsafe"] let makeUninitializedUnsafe = x => Array.makeUninitializedUnsafe(x)->toT;
+    [@dead "+makeUninitializedUnsafe"] let makeUninitializedUnsafe = x => Array.makeUninitializedUnsafe(x)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 40:3-44
-  make is never used
+  +make is never used
   <-- line 40
-    [@dead "make"] let make = (x, y) => Array.make(x, y)->toT;
+    [@dead "+make"] let make = (x, y) => Array.make(x, y)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 42:3-46
-  range is never used
+  +range is never used
   <-- line 42
-    [@dead "range"] let range = (x, y) => Array.range(x, y)->toT;
+    [@dead "+range"] let range = (x, y) => Array.range(x, y)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 44:3-64
-  rangeBy is never used
+  +rangeBy is never used
   <-- line 44
-    [@dead "rangeBy"] let rangeBy = (x, y, ~step) => Array.rangeBy(x, y, ~step)->toT;
+    [@dead "+rangeBy"] let rangeBy = (x, y, ~step) => Array.rangeBy(x, y, ~step)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 46:3-50
-  makeByU is never used
+  +makeByU is never used
   <-- line 46
-    [@dead "makeByU"] let makeByU = (c, f) => Array.makeByU(c, f)->toT;
+    [@dead "+makeByU"] let makeByU = (c, f) => Array.makeByU(c, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 47:3-48
-  makeBy is never used
+  +makeBy is never used
   <-- line 47
-    [@dead "makeBy"] let makeBy = (c, f) => Array.makeBy(c, f)->toT;
+    [@dead "+makeBy"] let makeBy = (c, f) => Array.makeBy(c, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 49:3-70
-  makeByAndShuffleU is never used
+  +makeByAndShuffleU is never used
   <-- line 49
-    [@dead "makeByAndShuffleU"] let makeByAndShuffleU = (c, f) => Array.makeByAndShuffleU(c, f)->toT;
+    [@dead "+makeByAndShuffleU"] let makeByAndShuffleU = (c, f) => Array.makeByAndShuffleU(c, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 50:3-68
-  makeByAndShuffle is never used
+  +makeByAndShuffle is never used
   <-- line 50
-    [@dead "makeByAndShuffle"] let makeByAndShuffle = (c, f) => Array.makeByAndShuffle(c, f)->toT;
+    [@dead "+makeByAndShuffle"] let makeByAndShuffle = (c, f) => Array.makeByAndShuffle(c, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 52:3-61
-  zip is never used
+  +zip is never used
   <-- line 52
-    [@dead "zip"] let zip = (a1, a2) => Array.zip(fromT(a1), fromT(a2))->toTp;
+    [@dead "+zip"] let zip = (a1, a2) => Array.zip(fromT(a1), fromT(a2))->toTp;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 54:3-72
-  zipByU is never used
+  +zipByU is never used
   <-- line 54
-    [@dead "zipByU"] let zipByU = (a1, a2, f) => Array.zipByU(fromT(a1), fromT(a2), f)->toT;
+    [@dead "+zipByU"] let zipByU = (a1, a2, f) => Array.zipByU(fromT(a1), fromT(a2), f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 55:3-70
-  zipBy is never used
+  +zipBy is never used
   <-- line 55
-    [@dead "zipBy"] let zipBy = (a1, a2, f) => Array.zipBy(fromT(a1), fromT(a2), f)->toT;
+    [@dead "+zipBy"] let zipBy = (a1, a2, f) => Array.zipBy(fromT(a1), fromT(a2), f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 57:3-47
-  unzip is never used
+  +unzip is never used
   <-- line 57
-    [@dead "unzip"] let unzip = a => Array.unzip(a->fromTp)->toT2;
+    [@dead "+unzip"] let unzip = a => Array.unzip(a->fromTp)->toT2;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 59:3-66
-  concat is never used
+  +concat is never used
   <-- line 59
-    [@dead "concat"] let concat = (a1, a2) => Array.concat(a1->fromT, a2->fromT)->toT;
+    [@dead "+concat"] let concat = (a1, a2) => Array.concat(a1->fromT, a2->fromT)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 61:3-67
-  concatMany is never used
+  +concatMany is never used
   <-- line 61
-    [@dead "concatMany"] let concatMany = (a: t(t(_))) => Array.concatMany(a->fromTT)->toT;
+    [@dead "+concatMany"] let concatMany = (a: t(t(_))) => Array.concatMany(a->fromTT)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 63:3-64:45
-  slice is never used
+  +slice is never used
   <-- line 63
-    [@dead "slice"] let slice = (a, ~offset, ~len) =>
+    [@dead "+slice"] let slice = (a, ~offset, ~len) =>
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 66:3-63
-  sliceToEnd is never used
+  +sliceToEnd is never used
   <-- line 66
-    [@dead "sliceToEnd"] let sliceToEnd = (a, b) => Array.sliceToEnd(a->fromT, b)->toT;
+    [@dead "+sliceToEnd"] let sliceToEnd = (a, b) => Array.sliceToEnd(a->fromT, b)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 68:3-43
-  copy is never used
+  +copy is never used
   <-- line 68
-    [@dead "copy"] let copy = a => Array.copy(a->fromT)->toT;
+    [@dead "+copy"] let copy = a => Array.copy(a->fromT)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 70:3-54
-  forEachU is never used
+  +forEachU is never used
   <-- line 70
-    [@dead "forEachU"] let forEachU = (a, f) => Array.forEachU(a->fromT, f);
+    [@dead "+forEachU"] let forEachU = (a, f) => Array.forEachU(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 71:3-52
-  forEach is never used
+  +forEach is never used
   <-- line 71
-    [@dead "forEach"] let forEach = (a, f) => Array.forEach(a->fromT, f);
+    [@dead "+forEach"] let forEach = (a, f) => Array.forEach(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 73:3-51
-  mapU is never used
+  +mapU is never used
   <-- line 73
-    [@dead "mapU"] let mapU = (a, f) => Array.mapU(a->fromT, f)->toT;
+    [@dead "+mapU"] let mapU = (a, f) => Array.mapU(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 74:3-49
-  map is never used
+  +map is never used
   <-- line 74
-    [@dead "map"] let map = (a, f) => Array.map(a->fromT, f)->toT;
+    [@dead "+map"] let map = (a, f) => Array.map(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 76:3-71
-  keepWithIndexU is never used
+  +keepWithIndexU is never used
   <-- line 76
-    [@dead "keepWithIndexU"] let keepWithIndexU = (a, f) => Array.keepWithIndexU(a->fromT, f)->toT;
+    [@dead "+keepWithIndexU"] let keepWithIndexU = (a, f) => Array.keepWithIndexU(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 77:3-69
-  keepWithIndex is never used
+  +keepWithIndex is never used
   <-- line 77
-    [@dead "keepWithIndex"] let keepWithIndex = (a, f) => Array.keepWithIndex(a->fromT, f)->toT;
+    [@dead "+keepWithIndex"] let keepWithIndex = (a, f) => Array.keepWithIndex(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 79:3-59
-  keepMapU is never used
+  +keepMapU is never used
   <-- line 79
-    [@dead "keepMapU"] let keepMapU = (a, f) => Array.keepMapU(a->fromT, f)->toT;
+    [@dead "+keepMapU"] let keepMapU = (a, f) => Array.keepMapU(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 80:3-57
-  keepMap is never used
+  +keepMap is never used
   <-- line 80
-    [@dead "keepMap"] let keepMap = (a, f) => Array.keepMap(a->fromT, f)->toT;
+    [@dead "+keepMap"] let keepMap = (a, f) => Array.keepMap(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 82:3-72
-  forEachWithIndexU is never used
+  +forEachWithIndexU is never used
   <-- line 82
-    [@dead "forEachWithIndexU"] let forEachWithIndexU = (a, f) => Array.forEachWithIndexU(a->fromT, f);
+    [@dead "+forEachWithIndexU"] let forEachWithIndexU = (a, f) => Array.forEachWithIndexU(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 83:3-70
-  forEachWithIndex is never used
+  +forEachWithIndex is never used
   <-- line 83
-    [@dead "forEachWithIndex"] let forEachWithIndex = (a, f) => Array.forEachWithIndex(a->fromT, f);
+    [@dead "+forEachWithIndex"] let forEachWithIndex = (a, f) => Array.forEachWithIndex(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 85:3-69
-  mapWithIndexU is never used
+  +mapWithIndexU is never used
   <-- line 85
-    [@dead "mapWithIndexU"] let mapWithIndexU = (a, f) => Array.mapWithIndexU(a->fromT, f)->toT;
+    [@dead "+mapWithIndexU"] let mapWithIndexU = (a, f) => Array.mapWithIndexU(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 86:3-67
-  mapWithIndex is never used
+  +mapWithIndex is never used
   <-- line 86
-    [@dead "mapWithIndex"] let mapWithIndex = (a, f) => Array.mapWithIndex(a->fromT, f)->toT;
+    [@dead "+mapWithIndex"] let mapWithIndex = (a, f) => Array.mapWithIndex(a->fromT, f)->toT;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 88:3-64
-  partitionU is never used
+  +partitionU is never used
   <-- line 88
-    [@dead "partitionU"] let partitionU = (a, f) => Array.partitionU(a->fromT, f)->toT2;
+    [@dead "+partitionU"] let partitionU = (a, f) => Array.partitionU(a->fromT, f)->toT2;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 89:3-62
-  partition is never used
+  +partition is never used
   <-- line 89
-    [@dead "partition"] let partition = (a, f) => Array.partition(a->fromT, f)->toT2;
+    [@dead "+partition"] let partition = (a, f) => Array.partition(a->fromT, f)->toT2;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 91:3-58
-  reduceU is never used
+  +reduceU is never used
   <-- line 91
-    [@dead "reduceU"] let reduceU = (a, b, f) => Array.reduceU(a->fromT, b, f);
+    [@dead "+reduceU"] let reduceU = (a, b, f) => Array.reduceU(a->fromT, b, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 92:3-56
-  reduce is never used
+  +reduce is never used
   <-- line 92
-    [@dead "reduce"] let reduce = (a, b, f) => Array.reduce(a->fromT, b, f);
+    [@dead "+reduce"] let reduce = (a, b, f) => Array.reduce(a->fromT, b, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 94:3-72
-  reduceReverseU is never used
+  +reduceReverseU is never used
   <-- line 94
-    [@dead "reduceReverseU"] let reduceReverseU = (a, b, f) => Array.reduceReverseU(a->fromT, b, f);
+    [@dead "+reduceReverseU"] let reduceReverseU = (a, b, f) => Array.reduceReverseU(a->fromT, b, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 95:3-70
-  reduceReverse is never used
+  +reduceReverse is never used
   <-- line 95
-    [@dead "reduceReverse"] let reduceReverse = (a, b, f) => Array.reduceReverse(a->fromT, b, f);
+    [@dead "+reduceReverse"] let reduceReverse = (a, b, f) => Array.reduceReverse(a->fromT, b, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 97:3-98:53
-  reduceReverse2U is never used
+  +reduceReverse2U is never used
   <-- line 97
-    [@dead "reduceReverse2U"] let reduceReverse2U = (a1, a2, c, f) =>
+    [@dead "+reduceReverse2U"] let reduceReverse2U = (a1, a2, c, f) =>
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 99:3-100:52
-  reduceReverse2 is never used
+  +reduceReverse2 is never used
   <-- line 99
-    [@dead "reduceReverse2"] let reduceReverse2 = (a1, a2, c, f) =>
+    [@dead "+reduceReverse2"] let reduceReverse2 = (a1, a2, c, f) =>
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 102:3-48
-  someU is never used
+  +someU is never used
   <-- line 102
-    [@dead "someU"] let someU = (a, f) => Array.someU(a->fromT, f);
+    [@dead "+someU"] let someU = (a, f) => Array.someU(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 103:3-46
-  some is never used
+  +some is never used
   <-- line 103
-    [@dead "some"] let some = (a, f) => Array.some(a->fromT, f);
+    [@dead "+some"] let some = (a, f) => Array.some(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 105:3-50
-  everyU is never used
+  +everyU is never used
   <-- line 105
-    [@dead "everyU"] let everyU = (a, f) => Array.everyU(a->fromT, f);
+    [@dead "+everyU"] let everyU = (a, f) => Array.everyU(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 106:3-48
-  every is never used
+  +every is never used
   <-- line 106
-    [@dead "every"] let every = (a, f) => Array.every(a->fromT, f);
+    [@dead "+every"] let every = (a, f) => Array.every(a->fromT, f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 108:3-69
-  every2U is never used
+  +every2U is never used
   <-- line 108
-    [@dead "every2U"] let every2U = (a1, a2, f) => Array.every2U(fromT(a1), fromT(a2), f);
+    [@dead "+every2U"] let every2U = (a1, a2, f) => Array.every2U(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 109:3-67
-  every2 is never used
+  +every2 is never used
   <-- line 109
-    [@dead "every2"] let every2 = (a1, a2, f) => Array.every2(fromT(a1), fromT(a2), f);
+    [@dead "+every2"] let every2 = (a1, a2, f) => Array.every2(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 111:3-67
-  some2U is never used
+  +some2U is never used
   <-- line 111
-    [@dead "some2U"] let some2U = (a1, a2, f) => Array.some2U(fromT(a1), fromT(a2), f);
+    [@dead "+some2U"] let some2U = (a1, a2, f) => Array.some2U(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 112:3-65
-  some2 is never used
+  +some2 is never used
   <-- line 112
-    [@dead "some2"] let some2 = (a1, a2, f) => Array.some2(fromT(a1), fromT(a2), f);
+    [@dead "+some2"] let some2 = (a1, a2, f) => Array.some2(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 114:3-63
-  cmpU is never used
+  +cmpU is never used
   <-- line 114
-    [@dead "cmpU"] let cmpU = (a1, a2, f) => Array.cmpU(fromT(a1), fromT(a2), f);
+    [@dead "+cmpU"] let cmpU = (a1, a2, f) => Array.cmpU(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 115:3-61
-  cmp is never used
+  +cmp is never used
   <-- line 115
-    [@dead "cmp"] let cmp = (a1, a2, f) => Array.cmp(fromT(a1), fromT(a2), f);
+    [@dead "+cmp"] let cmp = (a1, a2, f) => Array.cmp(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 117:3-61
-  eqU is never used
+  +eqU is never used
   <-- line 117
-    [@dead "eqU"] let eqU = (a1, a2, f) => Array.eqU(fromT(a1), fromT(a2), f);
+    [@dead "+eqU"] let eqU = (a1, a2, f) => Array.eqU(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.re 118:3-59
-  eq is never used
+  +eq is never used
   <-- line 118
-    [@dead "eq"] let eq = (a1, a2, f) => Array.eq(fromT(a1), fromT(a2), f);
+    [@dead "+eq"] let eq = (a1, a2, f) => Array.eq(fromT(a1), fromT(a2), f);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 10:1-31
-  toArray is never used
+  +toArray is never used
   <-- line 10
-  [@dead "toArray"] let toArray: t('a) => array('a);
+  [@dead "+toArray"] let toArray: t('a) => array('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 12:1-14:24
-  length is never used
+  +length is never used
   <-- line 12
-  [@dead "length"] /** Subset of the Belt.Array oprerations that do not mutate the array. */
+  [@dead "+length"] /** Subset of the Belt.Array oprerations that do not mutate the array. */
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 16:1-22
-  size is never used
+  +size is never used
   <-- line 16
-  [@dead "size"] let size: t('a) => int;
+  [@dead "+size"] let size: t('a) => int;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 18:1-35
-  get is never used
+  +get is never used
   <-- line 18
-  [@dead "get"] let get: (t('a), int) => option('a);
+  [@dead "+get"] let get: (t('a), int) => option('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 20:1-30
-  getExn is never used
+  +getExn is never used
   <-- line 20
-  [@dead "getExn"] let getExn: (t('a), int) => 'a;
+  [@dead "+getExn"] let getExn: (t('a), int) => 'a;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 22:1-33
-  getUnsafe is never used
+  +getUnsafe is never used
   <-- line 22
-  [@dead "getUnsafe"] let getUnsafe: (t('a), int) => 'a;
+  [@dead "+getUnsafe"] let getUnsafe: (t('a), int) => 'a;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 24:1-50
-  getUndefined is never used
+  +getUndefined is never used
   <-- line 24
-  [@dead "getUndefined"] let getUndefined: (t('a), int) => Js.undefined('a);
+  [@dead "+getUndefined"] let getUndefined: (t('a), int) => Js.undefined('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 26:1-27
-  shuffle is never used
+  +shuffle is never used
   <-- line 26
-  [@dead "shuffle"] let shuffle: t('a) => t('a);
+  [@dead "+shuffle"] let shuffle: t('a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 28:1-27
-  reverse is never used
+  +reverse is never used
   <-- line 28
-  [@dead "reverse"] let reverse: t('a) => t('a);
+  [@dead "+reverse"] let reverse: t('a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 30:1-49
-  makeUninitialized is never used
+  +makeUninitialized is never used
   <-- line 30
-  [@dead "makeUninitialized"] let makeUninitialized: int => t(Js.undefined('a));
+  [@dead "+makeUninitialized"] let makeUninitialized: int => t(Js.undefined('a));
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 32:1-41
-  makeUninitializedUnsafe is never used
+  +makeUninitializedUnsafe is never used
   <-- line 32
-  [@dead "makeUninitializedUnsafe"] let makeUninitializedUnsafe: int => t('a);
+  [@dead "+makeUninitializedUnsafe"] let makeUninitializedUnsafe: int => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 34:1-28
-  make is never used
+  +make is never used
   <-- line 34
-  [@dead "make"] let make: (int, 'a) => t('a);
+  [@dead "+make"] let make: (int, 'a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 36:1-31
-  range is never used
+  +range is never used
   <-- line 36
-  [@dead "range"] let range: (int, int) => t(int);
+  [@dead "+range"] let range: (int, int) => t(int);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 38:1-45
-  rangeBy is never used
+  +rangeBy is never used
   <-- line 38
-  [@dead "rangeBy"] let rangeBy: (int, int, ~step: int) => t(int);
+  [@dead "+rangeBy"] let rangeBy: (int, int, ~step: int) => t(int);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 40:1-42
-  makeByU is never used
+  +makeByU is never used
   <-- line 40
-  [@dead "makeByU"] let makeByU: (int, (. int) => 'a) => t('a);
+  [@dead "+makeByU"] let makeByU: (int, (. int) => 'a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 41:1-37
-  makeBy is never used
+  +makeBy is never used
   <-- line 41
-  [@dead "makeBy"] let makeBy: (int, int => 'a) => t('a);
+  [@dead "+makeBy"] let makeBy: (int, int => 'a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 43:1-52
-  makeByAndShuffleU is never used
+  +makeByAndShuffleU is never used
   <-- line 43
-  [@dead "makeByAndShuffleU"] let makeByAndShuffleU: (int, (. int) => 'a) => t('a);
+  [@dead "+makeByAndShuffleU"] let makeByAndShuffleU: (int, (. int) => 'a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 44:1-47
-  makeByAndShuffle is never used
+  +makeByAndShuffle is never used
   <-- line 44
-  [@dead "makeByAndShuffle"] let makeByAndShuffle: (int, int => 'a) => t('a);
+  [@dead "+makeByAndShuffle"] let makeByAndShuffle: (int, int => 'a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 46:1-38
-  zip is never used
+  +zip is never used
   <-- line 46
-  [@dead "zip"] let zip: (t('a), t('b)) => t(('a, 'b));
+  [@dead "+zip"] let zip: (t('a), t('b)) => t(('a, 'b));
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 48:1-53
-  zipByU is never used
+  +zipByU is never used
   <-- line 48
-  [@dead "zipByU"] let zipByU: (t('a), t('b), (. 'a, 'b) => 'c) => t('c);
+  [@dead "+zipByU"] let zipByU: (t('a), t('b), (. 'a, 'b) => 'c) => t('c);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 49:1-50
-  zipBy is never used
+  +zipBy is never used
   <-- line 49
-  [@dead "zipBy"] let zipBy: (t('a), t('b), ('a, 'b) => 'c) => t('c);
+  [@dead "+zipBy"] let zipBy: (t('a), t('b), ('a, 'b) => 'c) => t('c);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 51:1-40
-  unzip is never used
+  +unzip is never used
   <-- line 51
-  [@dead "unzip"] let unzip: t(('a, 'a)) => (t('a), t('a));
+  [@dead "+unzip"] let unzip: t(('a, 'a)) => (t('a), t('a));
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 53:1-35
-  concat is never used
+  +concat is never used
   <-- line 53
-  [@dead "concat"] let concat: (t('a), t('a)) => t('a);
+  [@dead "+concat"] let concat: (t('a), t('a)) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 55:1-33
-  concatMany is never used
+  +concatMany is never used
   <-- line 55
-  [@dead "concatMany"] let concatMany: t(t('a)) => t('a);
+  [@dead "+concatMany"] let concatMany: t(t('a)) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 57:1-52
-  slice is never used
+  +slice is never used
   <-- line 57
-  [@dead "slice"] let slice: (t('a), ~offset: int, ~len: int) => t('a);
+  [@dead "+slice"] let slice: (t('a), ~offset: int, ~len: int) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 59:1-37
-  sliceToEnd is never used
+  +sliceToEnd is never used
   <-- line 59
-  [@dead "sliceToEnd"] let sliceToEnd: (t('a), int) => t('a);
+  [@dead "+sliceToEnd"] let sliceToEnd: (t('a), int) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 61:1-24
-  copy is never used
+  +copy is never used
   <-- line 61
-  [@dead "copy"] let copy: t('a) => t('a);
+  [@dead "+copy"] let copy: t('a) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 63:1-45
-  forEachU is never used
+  +forEachU is never used
   <-- line 63
-  [@dead "forEachU"] let forEachU: (t('a), (. 'a) => unit) => unit;
+  [@dead "+forEachU"] let forEachU: (t('a), (. 'a) => unit) => unit;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 64:1-40
-  forEach is never used
+  +forEach is never used
   <-- line 64
-  [@dead "forEach"] let forEach: (t('a), 'a => unit) => unit;
+  [@dead "+forEach"] let forEach: (t('a), 'a => unit) => unit;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 66:1-40
-  mapU is never used
+  +mapU is never used
   <-- line 66
-  [@dead "mapU"] let mapU: (t('a), (. 'a) => 'b) => t('b);
+  [@dead "+mapU"] let mapU: (t('a), (. 'a) => 'b) => t('b);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 67:1-35
-  map is never used
+  +map is never used
   <-- line 67
-  [@dead "map"] let map: (t('a), 'a => 'b) => t('b);
+  [@dead "+map"] let map: (t('a), 'a => 'b) => t('b);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 69:1-57
-  keepWithIndexU is never used
+  +keepWithIndexU is never used
   <-- line 69
-  [@dead "keepWithIndexU"] let keepWithIndexU: (t('a), (. 'a, int) => bool) => t('a);
+  [@dead "+keepWithIndexU"] let keepWithIndexU: (t('a), (. 'a, int) => bool) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 70:1-54
-  keepWithIndex is never used
+  +keepWithIndex is never used
   <-- line 70
-  [@dead "keepWithIndex"] let keepWithIndex: (t('a), ('a, int) => bool) => t('a);
+  [@dead "+keepWithIndex"] let keepWithIndex: (t('a), ('a, int) => bool) => t('a);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 72:1-52
-  keepMapU is never used
+  +keepMapU is never used
   <-- line 72
-  [@dead "keepMapU"] let keepMapU: (t('a), (. 'a) => option('b)) => t('b);
+  [@dead "+keepMapU"] let keepMapU: (t('a), (. 'a) => option('b)) => t('b);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 73:1-47
-  keepMap is never used
+  +keepMap is never used
   <-- line 73
-  [@dead "keepMap"] let keepMap: (t('a), 'a => option('b)) => t('b);
+  [@dead "+keepMap"] let keepMap: (t('a), 'a => option('b)) => t('b);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 75:1-59
-  forEachWithIndexU is never used
+  +forEachWithIndexU is never used
   <-- line 75
-  [@dead "forEachWithIndexU"] let forEachWithIndexU: (t('a), (. int, 'a) => unit) => unit;
+  [@dead "+forEachWithIndexU"] let forEachWithIndexU: (t('a), (. int, 'a) => unit) => unit;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 76:1-56
-  forEachWithIndex is never used
+  +forEachWithIndex is never used
   <-- line 76
-  [@dead "forEachWithIndex"] let forEachWithIndex: (t('a), (int, 'a) => unit) => unit;
+  [@dead "+forEachWithIndex"] let forEachWithIndex: (t('a), (int, 'a) => unit) => unit;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 78:1-54
-  mapWithIndexU is never used
+  +mapWithIndexU is never used
   <-- line 78
-  [@dead "mapWithIndexU"] let mapWithIndexU: (t('a), (. int, 'a) => 'b) => t('b);
+  [@dead "+mapWithIndexU"] let mapWithIndexU: (t('a), (. int, 'a) => 'b) => t('b);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 79:1-51
-  mapWithIndex is never used
+  +mapWithIndex is never used
   <-- line 79
-  [@dead "mapWithIndex"] let mapWithIndex: (t('a), (int, 'a) => 'b) => t('b);
+  [@dead "+mapWithIndex"] let mapWithIndex: (t('a), (int, 'a) => 'b) => t('b);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 81:1-57
-  partitionU is never used
+  +partitionU is never used
   <-- line 81
-  [@dead "partitionU"] let partitionU: (t('a), (. 'a) => bool) => (t('a), t('a));
+  [@dead "+partitionU"] let partitionU: (t('a), (. 'a) => bool) => (t('a), t('a));
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 82:1-52
-  partition is never used
+  +partition is never used
   <-- line 82
-  [@dead "partition"] let partition: (t('a), 'a => bool) => (t('a), t('a));
+  [@dead "+partition"] let partition: (t('a), 'a => bool) => (t('a), t('a));
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 84:1-48
-  reduceU is never used
+  +reduceU is never used
   <-- line 84
-  [@dead "reduceU"] let reduceU: (t('a), 'b, (. 'b, 'a) => 'b) => 'b;
+  [@dead "+reduceU"] let reduceU: (t('a), 'b, (. 'b, 'a) => 'b) => 'b;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 85:1-45
-  reduce is never used
+  +reduce is never used
   <-- line 85
-  [@dead "reduce"] let reduce: (t('a), 'b, ('b, 'a) => 'b) => 'b;
+  [@dead "+reduce"] let reduce: (t('a), 'b, ('b, 'a) => 'b) => 'b;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 87:1-55
-  reduceReverseU is never used
+  +reduceReverseU is never used
   <-- line 87
-  [@dead "reduceReverseU"] let reduceReverseU: (t('a), 'b, (. 'b, 'a) => 'b) => 'b;
+  [@dead "+reduceReverseU"] let reduceReverseU: (t('a), 'b, (. 'b, 'a) => 'b) => 'b;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 88:1-52
-  reduceReverse is never used
+  +reduceReverse is never used
   <-- line 88
-  [@dead "reduceReverse"] let reduceReverse: (t('a), 'b, ('b, 'a) => 'b) => 'b;
+  [@dead "+reduceReverse"] let reduceReverse: (t('a), 'b, ('b, 'a) => 'b) => 'b;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 90:1-67
-  reduceReverse2U is never used
+  +reduceReverse2U is never used
   <-- line 90
-  [@dead "reduceReverse2U"] let reduceReverse2U: (t('a), t('b), 'c, (. 'c, 'a, 'b) => 'c) => 'c;
+  [@dead "+reduceReverse2U"] let reduceReverse2U: (t('a), t('b), 'c, (. 'c, 'a, 'b) => 'c) => 'c;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 91:1-64
-  reduceReverse2 is never used
+  +reduceReverse2 is never used
   <-- line 91
-  [@dead "reduceReverse2"] let reduceReverse2: (t('a), t('b), 'c, ('c, 'a, 'b) => 'c) => 'c;
+  [@dead "+reduceReverse2"] let reduceReverse2: (t('a), t('b), 'c, ('c, 'a, 'b) => 'c) => 'c;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 93:1-42
-  someU is never used
+  +someU is never used
   <-- line 93
-  [@dead "someU"] let someU: (t('a), (. 'a) => bool) => bool;
+  [@dead "+someU"] let someU: (t('a), (. 'a) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 94:1-37
-  some is never used
+  +some is never used
   <-- line 94
-  [@dead "some"] let some: (t('a), 'a => bool) => bool;
+  [@dead "+some"] let some: (t('a), 'a => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 96:1-43
-  everyU is never used
+  +everyU is never used
   <-- line 96
-  [@dead "everyU"] let everyU: (t('a), (. 'a) => bool) => bool;
+  [@dead "+everyU"] let everyU: (t('a), (. 'a) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 97:1-38
-  every is never used
+  +every is never used
   <-- line 97
-  [@dead "every"] let every: (t('a), 'a => bool) => bool;
+  [@dead "+every"] let every: (t('a), 'a => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 99:1-55
-  every2U is never used
+  +every2U is never used
   <-- line 99
-  [@dead "every2U"] let every2U: (t('a), t('b), (. 'a, 'b) => bool) => bool;
+  [@dead "+every2U"] let every2U: (t('a), t('b), (. 'a, 'b) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 100:1-52
-  every2 is never used
+  +every2 is never used
   <-- line 100
-  [@dead "every2"] let every2: (t('a), t('b), ('a, 'b) => bool) => bool;
+  [@dead "+every2"] let every2: (t('a), t('b), ('a, 'b) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 102:1-54
-  some2U is never used
+  +some2U is never used
   <-- line 102
-  [@dead "some2U"] let some2U: (t('a), t('b), (. 'a, 'b) => bool) => bool;
+  [@dead "+some2U"] let some2U: (t('a), t('b), (. 'a, 'b) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 103:1-51
-  some2 is never used
+  +some2 is never used
   <-- line 103
-  [@dead "some2"] let some2: (t('a), t('b), ('a, 'b) => bool) => bool;
+  [@dead "+some2"] let some2: (t('a), t('b), ('a, 'b) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 105:1-50
-  cmpU is never used
+  +cmpU is never used
   <-- line 105
-  [@dead "cmpU"] let cmpU: (t('a), t('a), (. 'a, 'a) => int) => int;
+  [@dead "+cmpU"] let cmpU: (t('a), t('a), (. 'a, 'a) => int) => int;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 106:1-47
-  cmp is never used
+  +cmp is never used
   <-- line 106
-  [@dead "cmp"] let cmp: (t('a), t('a), ('a, 'a) => int) => int;
+  [@dead "+cmp"] let cmp: (t('a), t('a), ('a, 'a) => int) => int;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 108:1-51
-  eqU is never used
+  +eqU is never used
   <-- line 108
-  [@dead "eqU"] let eqU: (t('a), t('a), (. 'a, 'a) => bool) => bool;
+  [@dead "+eqU"] let eqU: (t('a), t('a), (. 'a, 'a) => bool) => bool;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImmutableArray.rei 109:1-48
-  eq is never used
+  +eq is never used
   <-- line 109
-  [@dead "eq"] let eq: (t('a), t('a), ('a, 'a) => bool) => bool;
+  [@dead "+eq"] let eq: (t('a), t('a), ('a, 'a) => bool) => bool;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ImportHookDefault.re 2:3-14
@@ -3775,9 +3775,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ManyComponents.re 4:3-45
-  InnerComponent.someValueSoModuleOffsetsAreShifted is never used
+  InnerComponent.+someValueSoModuleOffsetsAreShifted is never used
   <-- line 4
-    [@dead "InnerComponent.someValueSoModuleOffsetsAreShifted"] let someValueSoModuleOffsetsAreShifted = 77;
+    [@dead "InnerComponent.+someValueSoModuleOffsetsAreShifted"] let someValueSoModuleOffsetsAreShifted = 77;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ModuleAliases.re 3:20-32
@@ -3817,51 +3817,51 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/ModuleAliases2.re 21:1-10
-  q is never used
+  +q is never used
   <-- line 21
-  [@dead "q"] let q = 42;
+  [@dead "+q"] let q = 42;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 8:3-22
-  Universe.notExported is never used
+  Universe.+notExported is never used
   <-- line 8
-    [@dead "Universe.notExported"] let notExported = 33;
+    [@dead "Universe.+notExported"] let notExported = 33;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 14:5-13
-  Universe.Nested2.x is never used
+  Universe.Nested2.+x is never used
   <-- line 14
-      [@dead "Universe.Nested2.x"] let x = 0;
+      [@dead "Universe.Nested2.+x"] let x = 0;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 19:5-13
-  Universe.Nested2.y is never used
+  Universe.Nested2.+y is never used
   <-- line 19
-      [@dead "Universe.Nested2.y"] let y = 2;
+      [@dead "Universe.Nested2.+y"] let y = 2;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 25:7-15
-  Universe.Nested2.Nested3.x is never used
+  Universe.Nested2.Nested3.+x is never used
   <-- line 25
-        [@dead "Universe.Nested2.Nested3.x"] let x = 0;
+        [@dead "Universe.Nested2.Nested3.+x"] let x = 0;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 26:7-15
-  Universe.Nested2.Nested3.y is never used
+  Universe.Nested2.Nested3.+y is never used
   <-- line 26
-        [@dead "Universe.Nested2.Nested3.y"] let y = 1;
+        [@dead "Universe.Nested2.Nested3.+y"] let y = 1;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 27:7-15
-  Universe.Nested2.Nested3.z is never used
+  Universe.Nested2.Nested3.+z is never used
   <-- line 27
-        [@dead "Universe.Nested2.Nested3.z"] let z = 2;
+        [@dead "Universe.Nested2.Nested3.+z"] let z = 2;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 28:7-15
-  Universe.Nested2.Nested3.w is never used
+  Universe.Nested2.Nested3.+w is never used
   <-- line 28
-        [@dead "Universe.Nested2.Nested3.w"] let w = 3;
+        [@dead "Universe.Nested2.Nested3.+w"] let w = 3;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/NestedModules.re 46:7
@@ -3967,39 +3967,39 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/RequireCond.re 1:1-12:15
-  make is never used
+  +make is never used
   <-- line 1
-  [@dead "make"] [@bs.module]
+  [@dead "+make"] [@bs.module]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/RequireCond.re 14:1-29:15
-  either is never used
+  +either is never used
   <-- line 14
-  [@dead "either"] [@bs.module]
+  [@dead "+either"] [@bs.module]
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Shadow.re 11:3-22
-  M.test is never used
+  M.+test is never used
   <-- line 11
-    [@dead "M.test"] let test = () => "a";
+    [@dead "M.+test"] let test = () => "a";
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TestImmutableArray.re 9:1-43
-  testBeltArrayGet is never used
+  +testBeltArrayGet is never used
   <-- line 9
-  [@dead "testBeltArrayGet"] let testBeltArrayGet = arr => Belt.(arr[3]);
+  [@dead "+testBeltArrayGet"] let testBeltArrayGet = arr => Belt.(arr[3]);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TestImmutableArray.re 11:1-47
-  testBeltArraySet is never used
+  +testBeltArraySet is never used
   <-- line 11
-  [@dead "testBeltArraySet"] let testBeltArraySet = arr => Belt.(arr[3] = 4);
+  [@dead "+testBeltArraySet"] let testBeltArraySet = arr => Belt.(arr[3] = 4);
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TestImport.re 18:1-43
-  innerStuffContents is never used
+  +innerStuffContents is never used
   <-- line 18
-  [@dead "innerStuffContents"] let innerStuffContents = innerStuffContents;
+  [@dead "+innerStuffContents"] let innerStuffContents = innerStuffContents;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TestImport.re 28:17-28
@@ -4009,9 +4009,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TestImport.re 42:1-15
-  make is never used
+  +make is never used
   <-- line 42
-  [@dead "make"] let make = make;
+  [@dead "+make"] let make = make;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TestPromise.re 6:3-8
@@ -4027,9 +4027,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TransitiveType2.re 7:1-28
-  convertT2 is never used
+  +convertT2 is never used
   <-- line 7
-  [@dead "convertT2"] let convertT2 = (x: t2) => x;
+  [@dead "+convertT2"] let convertT2 = (x: t2) => x;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TransitiveType3.re 3:3-8
@@ -4045,9 +4045,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TypeParams1.re 4:1-24
-  exportSomething is never used
+  +exportSomething is never used
   <-- line 4
-  [@dead "exportSomething"] let exportSomething = 10;
+  [@dead "+exportSomething"] let exportSomething = 10;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TypeParams2.re 2:14-20
@@ -4057,9 +4057,9 @@ File References
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/TypeParams2.re 10:1-24
-  exportSomething is never used
+  +exportSomething is never used
   <-- line 10
-  [@dead "exportSomething"] let exportSomething = 10;
+  [@dead "+exportSomething"] let exportSomething = 10;
 
   Warning Dead Type
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/Types.re 12:5-13

--- a/examples/deadcode/src/deadcode.txt
+++ b/examples/deadcode/src/deadcode.txt
@@ -1656,11 +1656,15 @@
   addValueReference DeadTest.re:100:4 --> DeadTest.re:100:45
   addValueDeclaration +unsafe_string2 DeadTest.re:107:2 path:+DeadTest.Ext_buffer
   addTypeReference DeadTest.re:110:16 --> DeadRT.rei:2:4
+  lazyLoad JSResource.jSResource(+DynamicallyLoadedComponent) JSResource.re:3:0 defined in DynamicallyLoadedComponent.re:2:4
+  addValueReference DeadTest.re:112:40 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest.re:112:40 --> JSResource.re:3:0
   addValueReference DeadTest.re:112:40 --> DeadTest.re:112:40
   addValueReference DeadTest.re:112:40 --> BootloaderResource.re:3:0
   addValueReference DeadTest.re:112:40 --> DeadTest.re:112:40
   addValueReference DeadTest.re:112:40 --> React.re:13:0
+  lazyLoad JSResource.jSResource(+DynamicallyLoadedComponent) JSResource.re:3:0 defined in DynamicallyLoadedComponent.re:2:4
+  addValueReference DeadTest.re:119:6 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest.re:119:6 --> JSResource.re:3:0
   addValueReference DeadTest.re:122:6 --> DeadTest.re:119:6
   addValueReference DeadTest.re:122:6 --> BootloaderResource.re:3:0
@@ -1676,10 +1680,12 @@
   addValueDeclaration +a1 DeadTest.re:151:6 path:+DeadTest
   addValueDeclaration +a2 DeadTest.re:152:6 path:+DeadTest
   addValueDeclaration +a3 DeadTest.re:153:6 path:+DeadTest
+  addValueReference DeadTest.re:157:17 --> DynamicallyLoadedComponent.re:2:4
   addValueReference DeadTest.re:157:17 --> React.re:13:0
   addValueReference DeadTest.re:160:4 --> DeadTest.re:159:4
   addValueReference DeadTest.re:167:4 --> DeadTest.re:167:11
   addValueReference DeadTest.re:167:4 --> React.re:5:0
+  addValueReference DeadTest.re:169:16 --> DeadTest.re:167:4
   addValueReference DeadTest.re:37:2 --> DeadTest.re:41:6
   addValueReference DeadTest.re:62:2 --> DeadTest.re:66:6
   addValueReference DeadTest.re:63:2 --> DeadTest.re:65:6
@@ -1710,7 +1716,7 @@ File References
   Docstrings.re -->> 
   TestPromise.re -->> 
   ModuleAliases.re -->> 
-  DeadTest.re -->> React.re, BootloaderResource.re, DeadValueTest.rei, ImmutableArray.rei, JSResource.re
+  DeadTest.re -->> React.re, BootloaderResource.re, DeadValueTest.rei, DynamicallyLoadedComponent.re, ImmutableArray.rei, JSResource.re
   AutoAnnotate.re -->> 
   ImportHooks.re -->> 
   NestedModulesInSignature.rei -->> NestedModulesInSignature.re
@@ -1818,7 +1824,7 @@ File References
   Live Type DeadRT.moduleAccessPath.Root: 1 references (DeadTest.re:110:16) [0]
   Dead Value +DeadTest.+stringLengthNoSideEffects: 0 references () [0]
   Dead Value +DeadTest.+theSideEffectIsLogging: 0 references () [0]
-  Dead Value +DeadTest.+make: 0 references () [0]
+  Live Value +DeadTest.+make: 1 references (DeadTest.re:169:16) [0]
   Dead Value +DeadTest.+makeSwitch: 0 references () [0]
   Dead Value +DeadTest.+deadRef: 0 references () [0]
   Dead Value +DeadTest.+minute: 0 references () [0]
@@ -1900,7 +1906,6 @@ File References
   Live Value +Docstrings.+one: 0 references () [0]
   Live Value +Docstrings.+signMessage: 0 references () [0]
   Live Value +Docstrings.+flat: 0 references () [0]
-  Live Value +DynamicallyLoadedComponent.+make: 1 references (DeadTest:0:-1) [0]
   Live Value +ExportWithRename.+make: 1 references (DeadTest:0:-1) [0]
   Live Value +FirstClassModules.+someFunctorAsFunction: 0 references () [0]
   Live Value +FirstClassModules.SomeFunctor.+ww: 1 references (FirstClassModules.re:46:20) [0]
@@ -2208,6 +2213,7 @@ File References
   Live Type +DeadTypeTest.+t.+A: 1 references (DeadTypeTest.re:4:8) [0]
   Dead Value DeadValueTest.+valueDead: 0 references () [0]
   Live Value DeadValueTest.+valueAlive: 1 references (DeadTest.re:77:16) [0]
+  Live Value +DynamicallyLoadedComponent.+make: 4 references (DeadTest.re:112:40, DeadTest.re:119:6, DeadTest.re:157:17, DeadTest:0:-1) [0]
   Dead Value ErrorHandler.+x: 0 references () [0]
   Live Value ErrorHandler.Make.+notify: 1 references (CreateErrorHandler1.re:8:0) [0]
   Dead Value +FirstClassModulesInterface.+r: 0 references () [0]
@@ -2754,12 +2760,6 @@ File References
   +makeSwitch is never used
   <-- line 164
   [@dead "+makeSwitch"] let makeSwitch = ComponentSwitch.make;
-
-  Warning Dead Value
-  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 166:1-167:31
-  +make is never used
-  <-- line 167
-  [@dead "+make"] [@react.component]
 
   Warning Dead Value With Side Effects
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 171:1-40

--- a/examples/deadcode/src/deadcode.txt
+++ b/examples/deadcode/src/deadcode.txt
@@ -1,9 +1,16 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ReasonComponent.cmt
   addValueDeclaration component ReasonComponent.re:3:4 path:+ReasonComponent
+  addTypeDeclaration name ReasonComponent.re:7:2 path:+ReasonComponent.person
+  addTypeDeclaration surname ReasonComponent.re:8:2 path:+ReasonComponent.person
+  addTypeDeclaration type_ ReasonComponent.re:9:2 path:+ReasonComponent.person
+  addTypeDeclaration polymorphicPayload ReasonComponent.re:11:2 path:+ReasonComponent.person
   addValueDeclaration onClick ReasonComponent.re:15:4 path:+ReasonComponent
   addValueDeclaration make ReasonComponent.re:18:4 path:+ReasonComponent
   addValueDeclaration minus ReasonComponent.re:43:4 path:+ReasonComponent
   addValueDeclaration useTypeDefinedInAnotherModule ReasonComponent.re:46:4 path:+ReasonComponent
+  addTypeDeclaration A ReasonComponent.re:50:4 path:+ReasonComponent.t
+  addTypeDeclaration B ReasonComponent.re:51:4 path:+ReasonComponent.t
+  addTypeDeclaration C ReasonComponent.re:52:4 path:+ReasonComponent.t
   addValueDeclaration tToString ReasonComponent.re:55:4 path:+ReasonComponent
   addValueDeclaration useRecordsCoord ReasonComponent.re:63:4 path:+ReasonComponent
   addValueReference ReasonComponent.re:3:4 --> ReasonReact.rei:153:0
@@ -41,21 +48,33 @@
   addTypeReference ReasonComponent.re:63:23 --> Records.re:5:2
   addTypeReference ReasonComponent.re:63:23 --> Records.re:6:2
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/FirstClassModulesInterface.cmti
+  addTypeDeclaration x FirstClassModulesInterface.rei:3:2 path:FirstClassModulesInterface.record
+  addTypeDeclaration y FirstClassModulesInterface.rei:4:2 path:FirstClassModulesInterface.record
   addValueDeclaration r FirstClassModulesInterface.rei:7:0 path:FirstClassModulesInterface
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Types.cmt
   addValueDeclaration someIntList Types.re:5:4 path:+Types
   addValueDeclaration map Types.re:8:4 path:+Types
+  addTypeDeclaration A Types.re:12:4 path:+Types.typeWithVars
+  addTypeDeclaration B Types.re:13:4 path:+Types.typeWithVars
   addValueDeclaration swap Types.re:28:8 path:+Types
+  addTypeDeclaration self Types.re:35:22 path:+Types.selfRecursive
+  addTypeDeclaration b Types.re:38:27 path:+Types.mutuallyRecursiveA
+  addTypeDeclaration a Types.re:39:26 path:+Types.mutuallyRecursiveB
   addValueDeclaration selfRecursiveConverter Types.re:46:4 path:+Types
   addValueDeclaration mutuallyRecursiveConverter Types.re:53:4 path:+Types
   addValueDeclaration testFunctionOnOptionsAsArgument Types.re:56:4 path:+Types
+  addTypeDeclaration A Types.re:60:4 path:+Types.opaqueVariant
+  addTypeDeclaration B Types.re:61:4 path:+Types.opaqueVariant
   addValueDeclaration stringT Types.re:64:4 path:+Types
   addValueDeclaration jsStringT Types.re:67:4 path:+Types
   addValueDeclaration jsString2T Types.re:70:4 path:+Types
   addValueDeclaration jsonStringify Types.re:82:4 path:+Types
+  addTypeDeclaration i Types.re:91:2 path:+Types.record
+  addTypeDeclaration s Types.re:92:2 path:+Types.record
   addValueDeclaration testConvertNull Types.re:96:4 path:+Types
   addValueDeclaration testMarshalFields Types.re:118:4 path:+Types
   addValueDeclaration setMatch Types.re:134:4 path:+Types
+  addTypeDeclaration id Types.re:139:19 path:+Types.someRecord
   addValueDeclaration testInstantiateTypeParameter Types.re:144:4 path:+Types
   addValueDeclaration currentTime Types.re:154:4 path:+Types
   addValueDeclaration i64Const Types.re:163:4 path:+Types
@@ -517,6 +536,8 @@
   addValueReference ImmutableArray.rei:108:0 --> ImmutableArray.re:117:6
   addValueReference ImmutableArray.rei:109:0 --> ImmutableArray.re:118:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TransitiveType3.cmt
+  addTypeDeclaration i TransitiveType3.re:3:2 path:+TransitiveType3.t3
+  addTypeDeclaration s TransitiveType3.re:4:2 path:+TransitiveType3.t3
   addValueDeclaration convertT3 TransitiveType3.re:8:4 path:+TransitiveType3
   addTypeDeclaration +i TransitiveType3.re:3:2 path:+TransitiveType3.+t3
   addTypeDeclaration +s TransitiveType3.re:4:2 path:+TransitiveType3.+t3
@@ -543,7 +564,10 @@
   addValueDeclaration testConvert2to3 Variants.re:80:4 path:+Variants
   addValueDeclaration id1 Variants.re:89:4 path:+Variants
   addValueDeclaration id2 Variants.re:92:4 path:+Variants
+  addTypeDeclaration Type Variants.re:97:4 path:+Variants.type_
   addValueDeclaration polyWithOpt Variants.re:100:4 path:+Variants
+  addTypeDeclaration Ok Variants.re:105:4 path:+Variants.result1
+  addTypeDeclaration Error Variants.re:106:4 path:+Variants.result1
   addValueDeclaration restResult1 Variants.re:115:4 path:+Variants
   addValueDeclaration restResult2 Variants.re:118:4 path:+Variants
   addValueDeclaration restResult3 Variants.re:121:4 path:+Variants
@@ -571,6 +595,8 @@
   addValueDeclaration uncurried3 Uncurried.re:23:4 path:+Uncurried
   addValueDeclaration curried3 Uncurried.re:27:4 path:+Uncurried
   addValueDeclaration callback Uncurried.re:30:4 path:+Uncurried
+  addTypeDeclaration login Uncurried.re:32:13 path:+Uncurried.auth
+  addTypeDeclaration loginU Uncurried.re:33:14 path:+Uncurried.authU
   addValueDeclaration callback2 Uncurried.re:36:4 path:+Uncurried
   addValueDeclaration callback2U Uncurried.re:39:4 path:+Uncurried
   addValueDeclaration sumU Uncurried.re:42:4 path:+Uncurried
@@ -626,6 +652,8 @@
   addValueDeclaration nested3Value NestedModules.re:34:10 path:+NestedModules.Universe.Nested2.Nested3
   addValueDeclaration nested3Function NestedModules.re:37:10 path:+NestedModules.Universe.Nested2.Nested3
   addValueDeclaration nested2Function NestedModules.re:41:8 path:+NestedModules.Universe.Nested2
+  addTypeDeclaration A NestedModules.re:46:6 path:+NestedModules.Universe.variant
+  addTypeDeclaration B NestedModules.re:47:6 path:+NestedModules.Universe.variant
   addValueDeclaration someString NestedModules.re:50:6 path:+NestedModules.Universe
   addValueReference NestedModules.re:37:10 --> NestedModules.re:37:29
   addValueReference NestedModules.re:41:8 --> NestedModules.re:41:27
@@ -637,6 +665,10 @@
   addValueDeclaration test Shadow.re:11:6 path:+Shadow.M
   addValueDeclaration +test Shadow.re:9:6 path:+Shadow.M
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ModuleAliases2.cmt
+  addTypeDeclaration x ModuleAliases2.re:3:2 path:+ModuleAliases2.record
+  addTypeDeclaration y ModuleAliases2.re:4:2 path:+ModuleAliases2.record
+  addTypeDeclaration outer ModuleAliases2.re:9:16 path:+ModuleAliases2.Outer.outer
+  addTypeDeclaration inner ModuleAliases2.re:13:18 path:+ModuleAliases2.Outer.Inner.inner
   addValueDeclaration q ModuleAliases2.re:21:4 path:+ModuleAliases2
   addTypeDeclaration +x ModuleAliases2.re:3:2 path:+ModuleAliases2.+record
   addTypeDeclaration +y ModuleAliases2.re:4:2 path:+ModuleAliases2.+record
@@ -655,6 +687,8 @@
   addValueDeclaration computeAreaWithIdent Tuples.re:17:4 path:+Tuples
   addValueDeclaration computeAreaNoConverters Tuples.re:21:4 path:+Tuples
   addValueDeclaration coord2d Tuples.re:24:4 path:+Tuples
+  addTypeDeclaration name Tuples.re:31:2 path:+Tuples.person
+  addTypeDeclaration age Tuples.re:32:2 path:+Tuples.person
   addValueDeclaration getFirstName Tuples.re:39:4 path:+Tuples
   addValueDeclaration marry Tuples.re:42:4 path:+Tuples
   addValueDeclaration changeSecondAge Tuples.re:45:4 path:+Tuples
@@ -688,6 +722,7 @@
   addValueReference TransitiveType1.re:2:4 --> TransitiveType1.re:2:15
   addValueReference TransitiveType1.re:5:4 --> TransitiveType1.re:5:20
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TypeParams2.cmt
+  addTypeDeclaration id TypeParams2.re:2:13 path:+TypeParams2.item
   addValueDeclaration exportSomething TypeParams2.re:10:4 path:+TypeParams2
   addTypeDeclaration +id TypeParams2.re:2:13 path:+TypeParams2.+item
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/FirstClassModules.cmt
@@ -718,9 +753,14 @@
   addValueDeclaration thisSpansSeveralLines DeadMl.ml:3:8 path:+DeadMl.QQ
   addValueDeclaration thisIsInInterface DeadMl.ml:9:2 path:+DeadMl.AA
   addValueDeclaration thisHasSemicolons DeadMl.ml:15:4 path:+DeadMl
+  addTypeDeclaration DeadA DeadMl.ml:17:18 path:+DeadMl.thisIsDead
+  addTypeDeclaration DeadB DeadMl.ml:17:26 path:+DeadMl.thisIsDead
   addValueDeclaration version DeadMl.ml:26:6 path:+DeadMl.Bs_version
   addValueDeclaration header DeadMl.ml:26:27 path:+DeadMl.Bs_version
   addValueDeclaration package_name DeadMl.ml:26:47 path:+DeadMl.Bs_version
+  addTypeDeclaration Lfunction DeadMl.ml:35:2 path:+DeadMl.l
+  addTypeDeclaration module_name DeadMl.ml:41:2 path:+DeadMl.module_info
+  addTypeDeclaration case DeadMl.ml:42:2 path:+DeadMl.module_info
   addValueDeclaration map_split_opt DeadMl.ml:45:8 path:+DeadMl
   addValueDeclaration inline_threshold DeadMl.ml:56:4 path:+DeadMl
   addValueDeclaration dead1 DeadMl.ml:59:6 path:+DeadMl.Scope
@@ -779,6 +819,7 @@
   addValueReference DeadMl.ml:99:2 --> DeadMl.ml:108:6
   addValueReference DeadMl.ml:103:2 --> DeadMl.ml:109:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportMyBanner.cmt
+  addTypeDeclaration text ImportMyBanner.re:6:16 path:+ImportMyBanner.message
   addValueDeclaration make ImportMyBanner.re:8:0 path:+ImportMyBanner
   addValueDeclaration make ImportMyBanner.re:19:4 path:+ImportMyBanner
   addTypeDeclaration +text ImportMyBanner.re:6:16 path:+ImportMyBanner.+message
@@ -805,6 +846,7 @@
   addValueReference TestModuleAliases.re:38:4 --> TestModuleAliases.re:38:18
   addValueReference TestModuleAliases.re:41:4 --> TestModuleAliases.re:41:26
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Opaque.cmt
+  addTypeDeclaration A Opaque.re:3:4 path:+Opaque.opaqueFromRecords
   addValueDeclaration noConversion Opaque.re:6:4 path:+Opaque
   addValueDeclaration testConvertNestedRecordFromOtherFile Opaque.re:12:4 path:+Opaque
   addTypeDeclaration +A Opaque.re:3:4 path:+Opaque.+opaqueFromRecords
@@ -838,14 +880,26 @@
   addValueDeclaration notify ErrorHandler.rei:5:32 path:ErrorHandler.Make
   addValueDeclaration x ErrorHandler.rei:7:0 path:ErrorHandler
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/VariantsWithPayload.cmt
+  addTypeDeclaration x VariantsWithPayload.re:2:2 path:+VariantsWithPayload.payload
+  addTypeDeclaration y VariantsWithPayload.re:3:2 path:+VariantsWithPayload.payload
   addValueDeclaration testWithPayload VariantsWithPayload.re:16:4 path:+VariantsWithPayload
   addValueDeclaration printVariantWithPayload VariantsWithPayload.re:19:4 path:+VariantsWithPayload
   addValueDeclaration testManyPayloads VariantsWithPayload.re:38:4 path:+VariantsWithPayload
   addValueDeclaration printManyPayloads VariantsWithPayload.re:41:4 path:+VariantsWithPayload
+  addTypeDeclaration A VariantsWithPayload.re:51:4 path:+VariantsWithPayload.simpleVariant
+  addTypeDeclaration B VariantsWithPayload.re:52:4 path:+VariantsWithPayload.simpleVariant
+  addTypeDeclaration C VariantsWithPayload.re:53:4 path:+VariantsWithPayload.simpleVariant
   addValueDeclaration testSimpleVariant VariantsWithPayload.re:56:4 path:+VariantsWithPayload
+  addTypeDeclaration A VariantsWithPayload.re:60:4 path:+VariantsWithPayload.variantWithPayloads
+  addTypeDeclaration B VariantsWithPayload.re:61:4 path:+VariantsWithPayload.variantWithPayloads
+  addTypeDeclaration C VariantsWithPayload.re:62:4 path:+VariantsWithPayload.variantWithPayloads
+  addTypeDeclaration D VariantsWithPayload.re:63:4 path:+VariantsWithPayload.variantWithPayloads
+  addTypeDeclaration E VariantsWithPayload.re:64:4 path:+VariantsWithPayload.variantWithPayloads
   addValueDeclaration testVariantWithPayloads VariantsWithPayload.re:67:4 path:+VariantsWithPayload
   addValueDeclaration printVariantWithPayloads VariantsWithPayload.re:70:4 path:+VariantsWithPayload
+  addTypeDeclaration R VariantsWithPayload.re:100:4 path:+VariantsWithPayload.variant1Int
   addValueDeclaration testVariant1Int VariantsWithPayload.re:103:4 path:+VariantsWithPayload
+  addTypeDeclaration R VariantsWithPayload.re:107:4 path:+VariantsWithPayload.variant1Object
   addValueDeclaration testVariant1Object VariantsWithPayload.re:110:4 path:+VariantsWithPayload
   addTypeDeclaration +x VariantsWithPayload.re:2:2 path:+VariantsWithPayload.+payload
   addTypeDeclaration +y VariantsWithPayload.re:3:2 path:+VariantsWithPayload.+payload
@@ -888,6 +942,8 @@
   addTypeDeclaration +R VariantsWithPayload.re:107:4 path:+VariantsWithPayload.+variant1Object
   addValueReference VariantsWithPayload.re:110:4 --> VariantsWithPayload.re:110:26
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/FirstClassModulesInterface.cmt
+  addTypeDeclaration x FirstClassModulesInterface.re:2:2 path:+FirstClassModulesInterface.record
+  addTypeDeclaration y FirstClassModulesInterface.re:3:2 path:+FirstClassModulesInterface.record
   addValueDeclaration r FirstClassModulesInterface.re:6:4 path:+FirstClassModulesInterface
   addTypeDeclaration +x FirstClassModulesInterface.re:2:2 path:+FirstClassModulesInterface.+record
   addTypeDeclaration +y FirstClassModulesInterface.re:3:2 path:+FirstClassModulesInterface.+record
@@ -895,7 +951,11 @@
   addValueReference FirstClassModulesInterface.rei:10:18 --> FirstClassModulesInterface.re:8:18
   addValueReference FirstClassModulesInterface.re:8:18 --> FirstClassModulesInterface.rei:10:18
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Unboxed.cmt
+  addTypeDeclaration A Unboxed.re:4:4 path:+Unboxed.v1
+  addTypeDeclaration A Unboxed.re:9:4 path:+Unboxed.v2
   addValueDeclaration testV1 Unboxed.re:12:4 path:+Unboxed
+  addTypeDeclaration x Unboxed.re:16:11 path:+Unboxed.r1
+  addTypeDeclaration B Unboxed.re:21:4 path:+Unboxed.r2
   addValueDeclaration r2Test Unboxed.re:24:4 path:+Unboxed
   addTypeDeclaration +A Unboxed.re:4:4 path:+Unboxed.+v1
   addTypeDeclaration +A Unboxed.re:9:4 path:+Unboxed.+v2
@@ -904,9 +964,17 @@
   addTypeDeclaration +B Unboxed.re:21:4 path:+Unboxed.+r2
   addValueReference Unboxed.re:24:4 --> Unboxed.re:24:14
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTypeTest.cmti
+  addTypeDeclaration A DeadTypeTest.rei:2:4 path:DeadTypeTest.t
+  addTypeDeclaration B DeadTypeTest.rei:3:4 path:DeadTypeTest.t
   addValueDeclaration a DeadTypeTest.rei:4:0 path:DeadTypeTest
+  addTypeDeclaration OnlyInImplementation DeadTypeTest.rei:7:4 path:DeadTypeTest.deadType
+  addTypeDeclaration OnlyInInterface DeadTypeTest.rei:8:4 path:DeadTypeTest.deadType
+  addTypeDeclaration InBoth DeadTypeTest.rei:9:4 path:DeadTypeTest.deadType
+  addTypeDeclaration InNeither DeadTypeTest.rei:10:4 path:DeadTypeTest.deadType
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportJsValue.cmt
   addValueDeclaration round ImportJsValue.re:1:0 path:+ImportJsValue
+  addTypeDeclaration x ImportJsValue.re:10:2 path:+ImportJsValue.point
+  addTypeDeclaration y ImportJsValue.re:11:2 path:+ImportJsValue.point
   addValueDeclaration area ImportJsValue.re:14:0 path:+ImportJsValue
   addValueDeclaration returnMixedArray ImportJsValue.re:21:0 path:+ImportJsValue
   addValueDeclaration roundedNumber ImportJsValue.re:25:4 path:+ImportJsValue
@@ -918,6 +986,8 @@
   addValueDeclaration useColor ImportJsValue.re:56:0 path:+ImportJsValue
   addValueDeclaration higherOrder ImportJsValue.re:58:0 path:+ImportJsValue
   addValueDeclaration returnedFromHigherOrder ImportJsValue.re:62:4 path:+ImportJsValue
+  addTypeDeclaration I ImportJsValue.re:65:4 path:+ImportJsValue.variant
+  addTypeDeclaration S ImportJsValue.re:66:4 path:+ImportJsValue.variant
   addValueDeclaration convertVariant ImportJsValue.re:68:0 path:+ImportJsValue
   addValueDeclaration polymorphic ImportJsValue.re:71:0 path:+ImportJsValue
   addValueDeclaration default ImportJsValue.re:73:0 path:+ImportJsValue
@@ -945,6 +1015,7 @@
   addValueDeclaration get References.re:31:4 path:+References
   addValueDeclaration make References.re:34:4 path:+References
   addValueDeclaration set References.re:37:4 path:+References
+  addTypeDeclaration x References.re:39:27 path:+References.requiresConversion
   addValueDeclaration destroysRefIdentity References.re:43:4 path:+References
   addValueDeclaration preserveRefIdentity References.re:47:4 path:+References
   addValueReference References.re:4:4 --> References.re:4:14
@@ -983,7 +1054,13 @@
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/BootloaderResource.cmt
   addValueDeclaration read BootloaderResource.re:3:0 path:+BootloaderResource
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadTypeTest.cmt
+  addTypeDeclaration A DeadTypeTest.re:2:4 path:+DeadTypeTest.t
+  addTypeDeclaration B DeadTypeTest.re:3:4 path:+DeadTypeTest.t
   addValueDeclaration a DeadTypeTest.re:4:4 path:+DeadTypeTest
+  addTypeDeclaration OnlyInImplementation DeadTypeTest.re:7:4 path:+DeadTypeTest.deadType
+  addTypeDeclaration OnlyInInterface DeadTypeTest.re:8:4 path:+DeadTypeTest.deadType
+  addTypeDeclaration InBoth DeadTypeTest.re:9:4 path:+DeadTypeTest.deadType
+  addTypeDeclaration InNeither DeadTypeTest.re:10:4 path:+DeadTypeTest.deadType
   addTypeDeclaration +A DeadTypeTest.re:2:4 path:+DeadTypeTest.+t
   addTypeDeclaration +B DeadTypeTest.re:3:4 path:+DeadTypeTest.+t
   addTypeReference DeadTypeTest.re:4:8 --> DeadTypeTest.re:2:4
@@ -1007,6 +1084,8 @@
   addValueDeclaration +x LetPrivate.re:2:12 path:+LetPrivate.local_1
   addValueReference LetPrivate.re:5:4 --> LetPrivate.re:2:12
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ModuleAliases.cmt
+  addTypeDeclaration inner ModuleAliases.re:3:19 path:+ModuleAliases.Outer.Inner.innerT
+  addTypeDeclaration nested ModuleAliases.re:11:16 path:+ModuleAliases.Outer2.Inner2.InnerNested.t
   addValueDeclaration testNested ModuleAliases.re:22:4 path:+ModuleAliases
   addValueDeclaration testInner ModuleAliases.re:25:4 path:+ModuleAliases
   addValueDeclaration testInner2 ModuleAliases.re:28:4 path:+ModuleAliases
@@ -1083,6 +1162,8 @@
   addValueDeclaration eqU ImmutableArray.rei:108:0 path:ImmutableArray
   addValueDeclaration eq ImmutableArray.rei:109:0 path:ImmutableArray
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportHookDefault.cmt
+  addTypeDeclaration name ImportHookDefault.re:2:2 path:+ImportHookDefault.person
+  addTypeDeclaration age ImportHookDefault.re:3:2 path:+ImportHookDefault.person
   addValueDeclaration makeProps ImportHookDefault.re:6:0 path:+ImportHookDefault
   addValueDeclaration make ImportHookDefault.re:6:0 path:+ImportHookDefault
   addValueDeclaration make2Props ImportHookDefault.re:16:0 path:+ImportHookDefault
@@ -1101,6 +1182,7 @@
   addValueDeclaration innerStuffContents TestImport.re:18:4 path:+TestImport
   addValueDeclaration valueStartingWithUpperCaseLetter TestImport.re:20:0 path:+TestImport
   addValueDeclaration defaultValue TestImport.re:24:0 path:+TestImport
+  addTypeDeclaration text TestImport.re:28:16 path:+TestImport.message
   addValueDeclaration make TestImport.re:30:0 path:+TestImport
   addValueDeclaration make TestImport.re:42:4 path:+TestImport
   addValueDeclaration defaultValue2 TestImport.re:44:0 path:+TestImport
@@ -1116,6 +1198,8 @@
   addValueReference TestImmutableArray.re:9:4 --> TestImmutableArray.re:9:23
   addValueReference TestImmutableArray.re:11:4 --> TestImmutableArray.re:11:23
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ImportHooks.cmt
+  addTypeDeclaration name ImportHooks.re:3:2 path:+ImportHooks.person
+  addTypeDeclaration age ImportHooks.re:4:2 path:+ImportHooks.person
   addValueDeclaration makeProps ImportHooks.re:15:0 path:+ImportHooks
   addValueDeclaration make ImportHooks.re:15:0 path:+ImportHooks
   addValueDeclaration foo ImportHooks.re:21:0 path:+ImportHooks
@@ -1134,6 +1218,8 @@
   addValueReference BucklescriptAnnotations.re:22:6 --> BucklescriptAnnotations.re:21:11
   addValueReference BucklescriptAnnotations.re:21:4 --> BucklescriptAnnotations.re:22:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadRT.cmti
+  addTypeDeclaration Root DeadRT.rei:2:4 path:DeadRT.moduleAccessPath
+  addTypeDeclaration Kaboom DeadRT.rei:3:4 path:DeadRT.moduleAccessPath
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/ComponentAsProp.cmt
   addValueDeclaration component ComponentAsProp.re:1:4 path:+ComponentAsProp
   addValueDeclaration make ComponentAsProp.re:5:4 path:+ComponentAsProp
@@ -1147,26 +1233,44 @@
   addValueReference ComponentAsProp.re:5:4 --> ReactDOMRe.re:1097:0
   addValueReference ComponentAsProp.re:5:4 --> ComponentAsProp.re:1:4
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Records.cmt
+  addTypeDeclaration x Records.re:5:2 path:+Records.coord
+  addTypeDeclaration y Records.re:6:2 path:+Records.coord
+  addTypeDeclaration z Records.re:7:2 path:+Records.coord
   addValueDeclaration origin Records.re:11:4 path:+Records
   addValueDeclaration computeArea Records.re:14:4 path:+Records
   addValueDeclaration coord2d Records.re:18:4 path:+Records
+  addTypeDeclaration name Records.re:22:2 path:+Records.person
+  addTypeDeclaration age Records.re:23:2 path:+Records.person
+  addTypeDeclaration address Records.re:24:2 path:+Records.person
+  addTypeDeclaration name Records.re:29:2 path:+Records.business
+  addTypeDeclaration owner Records.re:30:2 path:+Records.business
+  addTypeDeclaration address Records.re:31:2 path:+Records.business
   addValueDeclaration getOpt Records.re:34:4 path:+Records
   addValueDeclaration findAddress Records.re:37:4 path:+Records
   addValueDeclaration someBusiness Records.re:41:4 path:+Records
   addValueDeclaration findAllAddresses Records.re:44:4 path:+Records
+  addTypeDeclaration num Records.re:56:2 path:+Records.payload
+  addTypeDeclaration payload Records.re:57:2 path:+Records.payload
   addValueDeclaration getPayload Records.re:61:4 path:+Records
+  addTypeDeclaration v Records.re:65:2 path:+Records.record
+  addTypeDeclaration w Records.re:66:2 path:+Records.record
   addValueDeclaration getPayloadRecord Records.re:70:4 path:+Records
   addValueDeclaration recordValue Records.re:73:4 path:+Records
   addValueDeclaration payloadValue Records.re:76:4 path:+Records
   addValueDeclaration getPayloadRecordPlusOne Records.re:79:4 path:+Records
+  addTypeDeclaration name Records.re:86:2 path:+Records.business2
+  addTypeDeclaration owner Records.re:87:2 path:+Records.business2
+  addTypeDeclaration address2 Records.re:88:2 path:+Records.business2
   addValueDeclaration findAddress2 Records.re:92:4 path:+Records
   addValueDeclaration someBusiness2 Records.re:96:4 path:+Records
   addValueDeclaration computeArea3 Records.re:103:4 path:+Records
   addValueDeclaration computeArea4 Records.re:115:4 path:+Records
+  addTypeDeclaration type_ Records.re:141:2 path:+Records.myRec
   addValueDeclaration testMyRec Records.re:149:4 path:+Records
   addValueDeclaration testMyRec2 Records.re:152:4 path:+Records
   addValueDeclaration testMyObj Records.re:155:4 path:+Records
   addValueDeclaration testMyObj2 Records.re:158:4 path:+Records
+  addTypeDeclaration type_ Records.re:162:2 path:+Records.myRecBsAs
   addValueDeclaration testMyRecBsAs Records.re:167:4 path:+Records
   addValueDeclaration testMyRecBsAs2 Records.re:170:4 path:+Records
   addTypeDeclaration +x Records.re:5:2 path:+Records.+coord
@@ -1245,6 +1349,8 @@
   addValueReference Records.re:167:4 --> Records.re:167:21
   addValueReference Records.re:170:4 --> Records.re:170:22
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/DeadRT.cmt
+  addTypeDeclaration Root DeadRT.re:2:4 path:+DeadRT.moduleAccessPath
+  addTypeDeclaration Kaboom DeadRT.re:3:4 path:+DeadRT.moduleAccessPath
   addValueDeclaration emitModuleAccessPath DeadRT.re:5:8 path:+DeadRT
   addTypeDeclaration +Root DeadRT.re:2:4 path:+DeadRT.+moduleAccessPath
   addTypeDeclaration +Kaboom DeadRT.re:3:4 path:+DeadRT.+moduleAccessPath
@@ -1255,6 +1361,7 @@
   addValueDeclaration makeProps ImportIndex.re:2:0 path:+ImportIndex
   addValueDeclaration make ImportIndex.re:2:0 path:+ImportIndex
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/Hooks.cmt
+  addTypeDeclaration name Hooks.re:1:16 path:+Hooks.vehicle
   addValueDeclaration make Hooks.re:4:4 path:+Hooks
   addValueDeclaration default Hooks.re:36:4 path:+Hooks
   addValueDeclaration anotherComponent Hooks.re:40:4 path:+Hooks
@@ -1262,6 +1369,7 @@
   addValueDeclaration componentWithRenamedArgs Hooks.re:87:4 path:+Hooks
   addValueDeclaration makeWithRef Hooks.re:94:4 path:+Hooks
   addValueDeclaration testForwardRef Hooks.re:105:4 path:+Hooks
+  addTypeDeclaration x Hooks.re:107:10 path:+Hooks.r
   addValueDeclaration input Hooks.re:111:4 path:+Hooks
   addValueDeclaration polymorphicComponent Hooks.re:130:4 path:+Hooks
   addValueDeclaration functionReturningReactElement Hooks.re:134:4 path:+Hooks
@@ -1369,6 +1477,9 @@
   addValueReference Hooks.re:156:4 --> ReactDOMRe.re:1097:0
   addValueReference Hooks.re:156:4 --> ReactDOMRe.re:1097:0
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/TestPromise.cmt
+  addTypeDeclaration x TestPromise.re:6:2 path:+TestPromise.fromPayload
+  addTypeDeclaration s TestPromise.re:7:2 path:+TestPromise.fromPayload
+  addTypeDeclaration result TestPromise.re:11:18 path:+TestPromise.toPayload
   addValueDeclaration convert TestPromise.re:14:4 path:+TestPromise
   addTypeDeclaration +x TestPromise.re:6:2 path:+TestPromise.+fromPayload
   addTypeDeclaration +s TestPromise.re:7:2 path:+TestPromise.+fromPayload
@@ -1396,6 +1507,8 @@
   addValueDeclaration grouped Docstrings.re:52:4 path:+Docstrings
   addValueDeclaration unitArgWithoutConversion Docstrings.re:55:4 path:+Docstrings
   addValueDeclaration unitArgWithoutConversionU Docstrings.re:58:4 path:+Docstrings
+  addTypeDeclaration A Docstrings.re:61:4 path:+Docstrings.t
+  addTypeDeclaration B Docstrings.re:62:4 path:+Docstrings.t
   addValueDeclaration unitArgWithConversion Docstrings.re:65:4 path:+Docstrings
   addValueDeclaration unitArgWithConversionU Docstrings.re:68:4 path:+Docstrings
   addValueReference Docstrings.re:13:4 --> Docstrings.re:13:21
@@ -1434,6 +1547,13 @@
   addValueReference TestFirstClassModules.re:8:4 --> TestFirstClassModules.re:8:21
   addValueReference TestFirstClassModules.re:26:4 --> TestFirstClassModules.re:30:6
   Scanning /Users/cristianoc/reasonml/reanalyze/examples/deadcode/lib/bs/src/AutoAnnotate.cmt
+  addTypeDeclaration R AutoAnnotate.re:2:4 path:+AutoAnnotate.variant
+  addTypeDeclaration variant AutoAnnotate.re:5:15 path:+AutoAnnotate.record
+  addTypeDeclaration r2 AutoAnnotate.re:7:11 path:+AutoAnnotate.r2
+  addTypeDeclaration r3 AutoAnnotate.re:9:11 path:+AutoAnnotate.r3
+  addTypeDeclaration r4 AutoAnnotate.re:11:11 path:+AutoAnnotate.r4
+  addTypeDeclaration R2 AutoAnnotate.re:15:4 path:+AutoAnnotate.annotatedVariant
+  addTypeDeclaration R4 AutoAnnotate.re:16:4 path:+AutoAnnotate.annotatedVariant
   addTypeDeclaration +R AutoAnnotate.re:2:4 path:+AutoAnnotate.+variant
   addTypeDeclaration +variant AutoAnnotate.re:5:15 path:+AutoAnnotate.+record
   addTypeDeclaration +r2 AutoAnnotate.re:7:11 path:+AutoAnnotate.+r2
@@ -1451,7 +1571,10 @@
   addValueDeclaration thisIsUsedTwice DeadTest.re:10:4 path:+DeadTest
   addValueDeclaration thisIsKeptAlive DeadTest.re:17:4 path:+DeadTest
   addValueDeclaration thisIsMarkedLive DeadTest.re:20:4 path:+DeadTest
+  addTypeDeclaration A DeadTest.re:36:6 path:+DeadTest.VariantUsedOnlyInImplementation.t
   addValueDeclaration a DeadTest.re:37:2 path:+DeadTest.VariantUsedOnlyInImplementation
+  addTypeDeclaration xxx DeadTest.re:50:2 path:+DeadTest.record
+  addTypeDeclaration yyy DeadTest.re:51:2 path:+DeadTest.record
   addValueDeclaration x DeadTest.re:62:2 path:+DeadTest.MM
   addValueDeclaration y DeadTest.re:63:2 path:+DeadTest.MM
   addValueDeclaration unusedRec DeadTest.re:79:8 path:+DeadTest
@@ -1697,6 +1820,8 @@ File References
   Dead Value +DeadRT.emitModuleAccessPath: 0 references () [0]
   Live Type +DeadRT.+moduleAccessPath.+Kaboom: 1 references (DeadRT.re:11:16) [0]
   Dead Type +DeadRT.+moduleAccessPath.+Root: 0 references () [0]
+  Dead Type DeadRT.moduleAccessPath.Kaboom: 0 references () [0]
+  Live Type DeadRT.moduleAccessPath.Root: 1 references (DeadTest.re:110:16) [0]
   Dead Value +DeadTest.stringLengthNoSideEffects: 0 references () [0]
   Dead Value +DeadTest.theSideEffectIsLogging: 0 references () [0]
   Live Value +DeadTest.make: 1 references (DeadTest.re:169:16) [0]
@@ -1753,7 +1878,13 @@ File References
   Dead Value +DeadTestBlacklist.x: 0 references () [0]
   Dead Value +DeadTestWithInterface.Ext_buffer.x: 0 references () [0]
   Dead Value +DeadTestWithInterface.Ext_buffer.+x: 0 references () [0]
+  Dead Type DeadTypeTest.deadType.InNeither: 0 references () [0]
+  Live Type DeadTypeTest.deadType.InBoth: 1 references (DeadTest.re:47:8) [0]
+  Live Type DeadTypeTest.deadType.OnlyInInterface: 1 references (DeadTest.re:46:8) [0]
+  Dead Type DeadTypeTest.deadType.OnlyInImplementation: 0 references () [0]
   Dead Value DeadTypeTest.a: 0 references () [0]
+  Dead Type DeadTypeTest.t.B: 0 references () [0]
+  Dead Type DeadTypeTest.t.A: 0 references () [0]
   Live Value +Docstrings.unitArgWithConversionU: 0 references () [0]
   Live Value +Docstrings.unitArgWithConversion: 0 references () [0]
   Dead Type +Docstrings.+t.+B: 0 references () [0]
@@ -1787,6 +1918,8 @@ File References
   Live Value +FirstClassModules.M.InnerModule2.k: 1 references (FirstClassModules.re:7:24) [0]
   Live Value +FirstClassModules.M.y: 1 references (FirstClassModules.re:14:2) [0]
   Dead Value FirstClassModulesInterface.r: 0 references () [0]
+  Dead Type FirstClassModulesInterface.record.y: 0 references () [0]
+  Dead Type FirstClassModulesInterface.record.x: 0 references () [0]
   Dead Value +Hooks.aComponentWithChildren: 0 references () [0]
   Dead Value +Hooks.RenderPropRequiresConversion.+make: 0 references () [1]
   Dead Value +Hooks.RenderPropRequiresConversion.+unsafe_expr: 0 references () [0]
@@ -2480,6 +2613,12 @@ File References
   <-- line 5
   [@dead "emitModuleAccessPath"] let rec emitModuleAccessPath = moduleAccessPath =>
 
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadRT.rei 3:5-10
+  moduleAccessPath.Kaboom is a variant case which is never constructed
+  <-- line 3
+    | [@dead "moduleAccessPath.Kaboom"] Kaboom
+
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTest.re 2:1-17
   fortytwo is never used
@@ -2668,11 +2807,35 @@ File References
   <-- line 10
     | [@dead "+deadType.+InNeither"] InNeither;
 
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 2:5
+  t.A is a variant case which is never constructed
+  <-- line 2
+    | [@dead "t.A"] A
+
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 3:5
+  t.B is a variant case which is never constructed
+  <-- line 3
+    | [@dead "t.B"] B;
+
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 4:1-8
   a is never used
   <-- line 4
   [@dead "a"] let a: t;
+
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 7:5-24
+  deadType.OnlyInImplementation is a variant case which is never constructed
+  <-- line 7
+    | [@dead "deadType.OnlyInImplementation"] OnlyInImplementation
+
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadTypeTest.rei 10:5-13
+  deadType.InNeither is a variant case which is never constructed
+  <-- line 10
+    | [@dead "deadType.InNeither"] InNeither;
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/DeadValueTest.re 2:1-17
@@ -2727,6 +2890,18 @@ File References
   r is never used
   <-- line 6
   [@dead "r"] let r = {x: 3, y: "hello"};
+
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.rei 3:3-8
+  record.x is a record label never used to read a value
+  <-- line 3
+    [@dead "record.x"] x: int,
+
+  Warning Dead Type
+  /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.rei 4:3-11
+  record.y is a record label never used to read a value
+  <-- line 4
+    [@dead "record.y"] y: string,
 
   Warning Dead Value
   /Users/cristianoc/reasonml/reanalyze/examples/deadcode/src/FirstClassModulesInterface.rei 7:1-13

--- a/src/DeadCode.re
+++ b/src/DeadCode.re
@@ -4,6 +4,15 @@ let (+++) = Filename.concat;
 
 let rec processSignatureItem = (~doValues, ~path, si: Types.signature_item) =>
   switch (si) {
+  | Sig_type(_) =>
+    let (id, t) = si |> Compat.getSigType;
+    if (analyzeTypes^) {
+      DeadType.addDeclaration(
+        ~isInterface=true,
+        ~path=[id |> Ident.name |> Name.create, ...path],
+        t,
+      );
+    };
   | Sig_value(_) when doValues =>
     let (id, loc, kind) = si |> Compat.getSigValue;
     if (!loc.Location.loc_ghost) {

--- a/src/DeadCode.re
+++ b/src/DeadCode.re
@@ -2,61 +2,15 @@ open DeadCommon;
 
 let (+++) = Filename.concat;
 
-let rec processSignatureItem = (~doValues, ~path, si: Types.signature_item) =>
-  switch (si) {
-  | Sig_type(_) =>
-    let (id, t) = si |> Compat.getSigType;
-    if (analyzeTypes^) {
-      DeadType.addDeclaration(
-        ~isInterface=true,
-        ~path=[id |> Ident.name |> Name.create, ...path],
-        t,
-      );
-    };
-  | Sig_value(_) when doValues =>
-    let (id, loc, kind) = si |> Compat.getSigValue;
-    if (!loc.Location.loc_ghost) {
-      let isPrimitive =
-        switch (kind) {
-        | Val_prim(_) => true
-        | _ => false
-        };
-      if (!isPrimitive || analyzeExternals) {
-        addValueDeclaration(
-          ~sideEffects=false,
-          ~path,
-          ~loc,
-          Ident.name(id) |> Name.create,
-        );
-      };
-    };
-  | Sig_module(_)
-  | Sig_modtype(_) =>
-    switch (si |> Compat.getSigModuleModtype) {
-    | Some((id, moduleType)) =>
-      let collect =
-        switch (si) {
-        | Sig_modtype(_) => false
-        | _ => true
-        };
-      if (collect) {
-        DeadValue.getSignature(moduleType)
-        |> List.iter(
-             processSignatureItem(
-               ~doValues,
-               ~path=[id |> Ident.name |> Name.create, ...path],
-             ),
-           );
-      };
-    | None => ()
-    }
-  | _ => ()
-  };
-
-let processSignature = (~doValues, signature: Types.signature) => {
+let processSignature = (~doValues, ~doTypes, signature: Types.signature) => {
   signature
   |> List.iter(sig_item =>
-       processSignatureItem(~doValues, ~path=[currentModuleName^], sig_item)
+       DeadValue.processSignatureItem(
+         ~doValues,
+         ~doTypes,
+         ~path=[currentModuleName^],
+         sig_item,
+       )
      );
 };
 
@@ -114,14 +68,14 @@ let loadCmtFile = cmtFilePath => {
       switch (cmt_annots) {
       | Interface(signature) =>
         ProcessDeadAnnotations.signature(signature);
-        processSignature(~doValues=true, signature.sig_type);
+        processSignature(~doValues=true, ~doTypes=true, signature.sig_type);
       | Implementation(structure) =>
         let cmtiExists =
           Sys.file_exists(
             (cmtFilePath |> Filename.chop_extension) ++ ".cmti",
           );
         ProcessDeadAnnotations.structure(~doGenType=!cmtiExists, structure);
-        processSignature(~doValues=true, structure.str_type);
+        processSignature(~doValues=true, ~doTypes=true, structure.str_type);
         DeadValue.processStructure(
           ~doTypes=true,
           ~doValues=true,

--- a/src/DeadValue.re
+++ b/src/DeadValue.re
@@ -185,15 +185,14 @@ let collectExpr = (super, self, e: Typedtree.expression) => {
       | _ => path |> Path.head |> Ident.name |> Name.create
       };
 
-    let valueName = path |> Path.last |> Name.create;
+    let valueName = path |> Path.last |> Name.create(~isInterface=false);
     switch (getPosOfValue(~moduleName, ~valueName)) {
     | Some(posName) =>
-      assert(false); // XXX
       addValueReference(
         ~addFileReference=true,
         ~locFrom,
         ~locTo={loc_start: posName, loc_end: posName, loc_ghost: false},
-      );
+      )
     | None => ()
     };
 
@@ -210,11 +209,15 @@ let collectExpr = (super, self, e: Typedtree.expression) => {
         && Filename.check_suffix(s, ".bs") =>
     let moduleName =
       Filename.chop_extension(s) |> Name.create(~isInterface=false);
-    switch (getPosOfValue(~moduleName, ~valueName="make" |> Name.create)) {
+    switch (
+      getPosOfValue(
+        ~moduleName,
+        ~valueName="make" |> Name.create(~isInterface=false),
+      )
+    ) {
     | None => ()
     | Some(posMake) =>
       if (verbose) {
-        assert(false); // XXX
         Log_.item(
           "lazyLoad %s(%s) %s defined in %s@.",
           path |> Path.name,


### PR DESCRIPTION
TODO:
- deduplicate `processSignatureItem` on `DeadCode.re` and `DeadValue.re`
- restore references between the type definiion in the interface and implementation files